### PR TITLE
update readme files for SDK and other references to be more current

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,38 +50,20 @@ or the `VbsEnclaveSDK` project inside a project that consumes the nuget package.
 
 VbsEnclaveSDK usage
 ------------
-Currently the `VbsEnclaveSDK` project is what builds the SDK. The SDK contains
-an `Includes` folder with header files for the SDK and a `Sources` file with the 
-C/C++ files for any implementation. 
+Currently the SDK is located inside a separate solution file called `vbs_enclave_implementation_library.sln` 
+located in `./src/VbsEnclaveSDK`.
 
-Both the `Includes` and the `Sources` folders are automatically added to a project
-that consume the `VbsEnclavesTooling` nuget package. These projects can access the
-SDK headers by simply using a `#include` preprocessor directive like below:
+To view and load the SDK Launch and build the solution. For further information on building and interacting
+with the SDK you can view the SDK specific README file [here](./src/VbsEnclaveSDK/README.md).
 
-```C
-#include <VbsEnclaveSDK\Includes\VbsEnclaveSDK.h>
-
-// use methods/types in form the SDK's .h files e.g VbsEnclaveSDK.h
-
-```
-
-During build time the `Microsoft.Windows.VbsEnclaveTooling.targets` targets file
-will build the files in the `Sources` folder into the consuming project.
-
-`Note:` The SDK and its consumption is still a work in progress.
-
-Sample App
-------------
-In the future we will add a "Sample App project solution" to the repository
-for testing and also a VSIX project template as well.
+The SDK also contains a sample hostApp and sample enclave project where you can view how a developer interacts
+with the SDK.
 
 General Information
 ------------
 
 Each project should have their own `README.md` file so you should read those
 before changing anything. They might contain more information specific to the project.
-
-
 
 Contributing
 ------------

--- a/src/ToolingNuget/README.md
+++ b/src/ToolingNuget/README.md
@@ -3,15 +3,12 @@ ToolingNuget
 
 Creating a nuget package file (.nupkg)
 ------------
-When this project builds it uses the `ToolingExecutable` and the
-`VbsEnclaveSDK` projects to generate a nuget package that other
-projects can consume. The nuget package will contain a few things
+When this project builds it uses the `ToolingExecutable` project
+to generate a nuget package that other projects can consume. 
+The nuget package will contain a few things:
 
 1. The `VbsEnclaveTooling.exe` file that will be used to generate
    code that will marshal data to and from an enclave.
-1. The `VbsEnclaveSDK` projects source files to be
-   built by the project that consumes it at build time via a targets
-   file.
 1. The `Microsoft.VbsEnclaveTooling.props` and `Microsoft.VbsEnclaveTooling.targets`
    files.
 

--- a/src/VbsEnclaveSDK/README.md
+++ b/src/VbsEnclaveSDK/README.md
@@ -3,49 +3,22 @@ VbsEnclaveSDK
 
 Introduction
 ------------
-This project contains all the source code related to the SDK.
-These source files will be added to the developers project once
-they add the `VbsEnclaveTooling` nuget package. This will allow the
-developer to control whether they want to compile the CRT the
-SDK uses with /MT, /MTd, /MD or /MDd.
+This project contains all the source code related to the SDK. The SDK
+produces a static library for the hostApp and one for the enclave. 
+`veil_host_lib` and `veil_enclave_lib` respectively.
 
-See the `Microsoft.Windows.VbsEnclaveTooling.targets` file which
-is invoked during build time. It contains the target that is used
-to build include the SDK header files and C/C++ files to be consumed
-by another project.
+This is still being fleshed out but you can view the usage patterns in both
+the `sample_enclave` and `sample_hostapp` projects. Note about building
+the sample enclave project locally. You can follow the instructions here: 
+[Signing VBS enclave DLLs](https://learn.microsoft.com/en-us/windows/win32/trusted-execution/vbs-enclaves-dev-guide#step-3-signing-vbs-enclave-dlls),
+to create a certificate for your enclave. Then you can edit the `EnclaveCertName`
+property within the `sample_enclave` vcxproj file located here
+in the [sample_enclave.vcxproj](https://github.com/microsoft/VbsEnclaveTooling/blob/8179c372186bd7ab1f1d68ac044fe4a98ccc7eef/src/VbsEnclaveSDK/samples/sample_enclave/sample_enclave.vcxproj#L54)
+with the name of your signing certificate.
 
-Developer loop:
-1. Following the repositories `README.md` file in the root folder.
-1. In your `HostApp` project and `Enclave` project you should now
-   be able to use the SDK header files in the `VbsEnclaveSDK\Includes`
-   folder of of this project. 
-1. You can also now build both either project. During the build
-   Visual Studio will build the `VbsEnclaveSDK\Sources` files directly 
-   into the the project. 
-
-
-### Note 1:
-Your enclave project will receive CRT errors if C++ is
-is enabled. This is a work in progress as we'll need to
-provide stub functions for functionality not supported
-by enclaves. For now, the SDK is in C so the end-to-end
-scenario can be tested.
-
-### Note 2:
-The path `VbsEnclaveSDK\*` matter during build time. If
-you decide to change this folder name and its contents
-be sure to also change the `.nuspec` file in the `ToolingNuget`
-project as well as the `VbsEnclaveSDK` targets located
-in the `Microsoft.Windows.VbsEnclaveTooling.targets` file.
-
-### Note 3:
-The C/C++ files don't use a precompiled header so there will
-be an error if a project uses them that is consuming the SDK.
-This will/can be fixed before release as the SDK gets fleshed
-out. In the mean time you can use the `Not Using Precompiled Headers`
-option in your projects properties. Specifically in the
-C/C++ > precompiled headers section before consuming the SDK.
-
+Currently supported features:
+1. "Taskpool" support for the enclave by the HostApp. The enclave can now queue work onto vtl0 threads easily using std::future/std::promise behavior.
+   See TaskPool sample [here](./samples/sample_hostapp/sample_taskpool.cpp)
 
 Consumption
 ------------


### PR DESCRIPTION
Now that the SDK is located inside a separate solution file called `vbs_enclave_implementation_library.sln` located in `./src/VbsEnclaveSDK`, the README file has been updated to reflect that. I updated the sdk readme to contain the current state of the sdk.

References to the old style SDK have been removed as well.