### PR TITLE
Fix AV: Support callbacks from multiple registration sources

### DIFF
--- a/SampleApps/SampleApps/SampleApp1/main.cpp
+++ b/SampleApps/SampleApps/SampleApp1/main.cpp
@@ -20,6 +20,11 @@
 
 namespace fs = std::filesystem;
 
+void VbsEnclave::VTL0_Stubs::SampleEnclave::Hi_callback(void)
+{
+    std::cout << "sdfdsfds :!!!!!!!!!!!!!!!!!!!!!!! ";
+}
+
 int EncryptFlow(
     void* enclave, 
     const std::wstring& input, 

--- a/SampleApps/SampleApps/SampleEnclave/my_exports.cpp
+++ b/SampleApps/SampleApps/SampleEnclave/my_exports.cpp
@@ -260,6 +260,8 @@ HRESULT VbsEnclave::VTL1_Declarations::RunTaskpoolExample(_In_ const std::uint32
 {
     using namespace veil::vtl1::vtl0_functions;
 
+    VbsEnclave::VTL0_Callbacks::Hi_callback();
+
     debug_print(L"TEST: Taskpool destruction, don't wait for all tasks to finish");
     RunTaskpoolExamples::Test_Dont_WaitForAllTasksToFinish(threadCount);
     debug_print(L"");

--- a/SampleApps/SampleApps/SampleEnclaveInterface.edl
+++ b/SampleApps/SampleApps/SampleEnclaveInterface.edl
@@ -43,4 +43,9 @@ enclave
             );
     };
 
+    untrusted
+    {
+        void Hi();
+    };
+
 };

--- a/src/ToolingSharedLibrary/Includes/CodeGeneration/Contants.h
+++ b/src/ToolingSharedLibrary/Includes/CodeGeneration/Contants.h
@@ -98,8 +98,6 @@ namespace VbsEnclaveABI::Enclave::VTL0CallBackHelpers
     __declspec(selectany) LPENCLAVE_ROUTINE s_vtl0_allocation_function = nullptr;
     __declspec(selectany) LPENCLAVE_ROUTINE s_vtl0_deallocation_function = nullptr;
     __declspec(selectany) wil::srwlock s_vtl0_function_table_lock {{}};
-    __declspec(selectany) bool s_are_functions_registered {{}};
-    __declspec(selectany) std::unordered_map<std::uint32_t, std::uint64_t> s_vtl0_function_table{{}};
 }}
 namespace VbsEnclaveABI::Enclave::MemoryChecks
 {{
@@ -110,6 +108,8 @@ namespace VbsEnclaveABI::Enclave::MemoryChecks
 // END: DO NOT MODIFY: For internal abi usage
 namespace {}
 {{
+    VbsEnclaveABI::Enclave::VTL0CallBackHelpers::CallbacksState g_callbacks_state;
+
     namespace VTL1_Stubs
     {{
     {}
@@ -160,7 +160,7 @@ namespace {}
  R"(HRESULT hr = CallVtl0CallbackImplFromVtl0<ParamsT, ReturnParamsT, decltype({}_Abi_Impl)>(function_context, {}_Abi_Impl);)";
 
     static inline constexpr std::string_view c_vtl1_call_to_vtl0_callback =
- R"(THROW_IF_FAILED((CallVtl0CallbackFromVtl1<ParamsT, ReturnParamsT>({}U, flatbuffer_builder, function_result)));)";
+ R"(THROW_IF_FAILED((CallVtl0CallbackFromVtl1<ParamsT, ReturnParamsT>(g_callbacks_state, {}U, flatbuffer_builder, function_result)));)";
 
     // Using a R("...") that contains a " character with std::format ends up adding a \" to the string.
     // instead of the double quote itself. So, as a work around we'll use the old style of declaring a multi line string.
@@ -216,6 +216,8 @@ namespace {}\n\
     static inline constexpr std::string_view c_vtl1_enclave_func_impl_namespace = R"(
 namespace {}
 {{
+    extern VbsEnclaveABI::Enclave::VTL0CallBackHelpers::CallbacksState g_callbacks_state;
+
     namespace VTL1_Declarations
     {{
         {}
@@ -409,7 +411,7 @@ R"(     {}_Generated_Stub
             _In_ FlatbuffersDevTypes::AbiRegisterVtl0Callbacks_argsT in_params,
             _Inout_ flatbuffers::FlatBufferBuilder& flatbuffer_out_params_builder)
         {{
-            THROW_IF_FAILED(AddVtl0FunctionsToTable(in_params.callbacks));
+            THROW_IF_FAILED(AddVtl0FunctionsToTable(g_callbacks_state, in_params.callbacks));
 
             FlatbuffersDevTypes::AbiRegisterVtl0Callbacks_argsT  result{{}};
             result.m__return_value_ = S_OK;

--- a/src/ToolingSharedLibrary/Includes/VbsEnclaveABI/Enclave/EnclaveHelpers.h
+++ b/src/ToolingSharedLibrary/Includes/VbsEnclaveABI/Enclave/EnclaveHelpers.h
@@ -106,11 +106,12 @@ namespace VbsEnclaveABI::Enclave
     // its associated VTL0 callback.
     template <typename ParamsT, typename ReturnParamsT>
     static inline HRESULT CallVtl0CallbackFromVtl1(
+        _In_ const VbsEnclaveABI::Enclave::VTL0CallBackHelpers::CallbacksState& state,
         _In_ std::uint32_t function_index,
         _In_ flatbuffers::FlatBufferBuilder& flatbuffer_in_params_builder,
         _Inout_ ReturnParamsT& callback_result)
     {
-        bool func_index_in_table = s_vtl0_function_table.contains(function_index);
+        bool func_index_in_table = state.m_vtl0_function_table.contains(function_index);
         RETURN_HR_IF(E_INVALIDARG, !func_index_in_table);
 
         vtl0_memory_ptr<std::uint8_t> vtl0_in_params;
@@ -137,7 +138,7 @@ namespace VbsEnclaveABI::Enclave
             sizeof(EnclaveFunctionContext)));
 
         void* vtl0_output_buffer;
-        auto vtl0_callback = reinterpret_cast<LPENCLAVE_ROUTINE>(s_vtl0_function_table.at(function_index));
+        auto vtl0_callback = reinterpret_cast<LPENCLAVE_ROUTINE>(state.m_vtl0_function_table.at(function_index));
 
         RETURN_IF_WIN32_BOOL_FALSE((CallEnclave(
             vtl0_callback,


### PR DESCRIPTION
# Issue
If sample app calls VbsEnclave::VTL1_Stubs::RegisterVtl0Callbacks, it stores the callbacks in a global table,
    std::unordered_map<std::uint32_t, std::uint64_t> s_vtl0_function_table;

If veil then calls VbsEnclave::VTL1_Stubs::RegisterVtl0Callbacks, it tries to store the same callbacks in the same global table, but will bail out early because the global bool (s_are_functions_registered) is already true.

Calling a vail callback will then Access-Violate (if outside of the table range), or call a 'random' sample app callback (if one exists in that callback slot).

# Fix
Split the s_vtl0_function_table into a "per-consumer-abi-namespace" table copy.