### PR TITLE
Ensure all TUs use same codegen version

### DIFF
--- a/src/ToolingNuget/Nuget/Microsoft.Windows.VbsEnclave.CodeGenerator.targets
+++ b/src/ToolingNuget/Nuget/Microsoft.Windows.VbsEnclave.CodeGenerator.targets
@@ -5,6 +5,7 @@
             The <VbsEnclaveCodegenPackageDir> should always point to this folder. Our targets file will be placed in
             <ProjectRoot>\packages\<name of nuget package>\build\native. 
          -->
+        <VbsEnclaveCodegenVersion>0.0.0-preview</VbsEnclaveCodegenVersion>
         <VbsEnclaveCodegenPackageDir>$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)))..\..\</VbsEnclaveCodegenPackageDir>
         <VbsEnclaveExeFilePath>$(VbsEnclaveCodegenPackageDir)bin\$(Platform)\edlcodegen.exe</VbsEnclaveExeFilePath>
         <VbsEnclavePackageEnclaveAbiPath>$(VbsEnclaveCodegenPackageDir)src\VbsEnclaveABI</VbsEnclavePackageEnclaveAbiPath>
@@ -52,7 +53,7 @@
 
         <!-- define the __ENCLAVE_PROJECT__ macro in the enclave project so the enclave related ABI code lights up in the project.-->
         <ClCompile Condition="'$(VbsEnclaveVirtualTrustLayer)' == 'Enclave'">
-            <PreprocessorDefinitions>__ENCLAVE_PROJECT__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+            <PreprocessorDefinitions>__ENCLAVE_PROJECT__;__VBS_ENCLAVE_CODEGEN_VERSION__="$(VbsEnclaveCodegenVersion)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
         </ClCompile>
 
         <!-- The onecore.lib static library is required for host app projects. Add it by default to the host app-->

--- a/src/ToolingSharedLibrary/Includes/VbsEnclaveABI/Enclave/EnclaveHelpers.h
+++ b/src/ToolingSharedLibrary/Includes/VbsEnclaveABI/Enclave/EnclaveHelpers.h
@@ -6,6 +6,10 @@
 #error This header can only be included in an Enclave project (never the HostApp).
 #endif
 
+#if !defined(__VBS_ENCLAVE_CODEGEN_VERSION__)
+#error "VBS enclave code generator consumed without without version specified"
+#endif
+
 #include <VbsEnclaveABI\Shared\VbsEnclaveAbiBase.h>
 #include <VbsEnclaveABI\Enclave\Vtl0Pointers.h>
 #include <VbsEnclaveABI\Enclave\MemoryAllocation.h>
@@ -15,7 +19,7 @@ using namespace VbsEnclaveABI::Enclave::Pointers;
 using namespace VbsEnclaveABI::Shared;
 
 // Version to ensure all translation units are consuming a consistent version of the codegen
-#pragma detect_mismatch("VBS_ENCLAVE_CODEGEN_VERSION", "0.0.1-preview")
+#pragma detect_mismatch("__VBS_ENCLAVE_CODEGEN_VERSION__", __VBS_ENCLAVE_CODEGEN_VERSION__)
 
 // Default all projects consuming VBS Enclave codegen to having restricted memory access enabled.
 // See: https://learn.microsoft.com/en-us/windows/win32/api/winenclaveapi/nf-winenclaveapi-enclaverestrictcontainingprocessaccess


### PR DESCRIPTION
You'll now get errors like the following if using 2 different codegen versions when building your .dll
1>Stubs.cpp
1>veil_enclave_lib.lib(logger.vtl1.obj) : error LNK2038: mismatch detected for 'VBS_ENCLAVE_CODEGEN_VERSION': value '0.0.1-preview' doesn't match value '0.0.2-preview' in my_exports.obj
