### PR TITLE
Add sync mirror template for ADO pipeline and new public feeds to nuget.config files

### DIFF
--- a/AzurePipelineTemplates/SyncMirror-Pipeline-Template.yml
+++ b/AzurePipelineTemplates/SyncMirror-Pipeline-Template.yml
@@ -1,0 +1,68 @@
+# Sync branches in a mirror repository to a base repo by running this pipeline
+# from the mirror repo, and supplying the base repo as a parameter
+name: $(BuildDefinitionName)_$(date:yyMMdd)$(rev:.r)
+
+parameters:
+  - name: "SourceToTargetBranches"
+    type: object
+    default:
+      main: main
+  - name: "SourceRepository"
+    type: string
+    default: "https://github.com/microsoft/VbsEnclaveTooling.git"
+
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: Azure-Pipelines-1ESPT-ExDShared
+      image: windows-2022
+      os: windows
+    customBuildTags:
+    - ES365AIMigrationTooling
+    stages:
+    - stage: stage
+      jobs:
+        - job: SyncMirror
+          strategy:
+            matrix:
+              ${{ each branches in parameters.SourceToTargetBranches }}:
+                ${{ branches.key }}:
+                  SourceBranch: ${{ branches.key }}
+                  TargetBranch: ${{ branches.value }}
+          dependsOn: []
+          steps:
+            - checkout: self
+              persistCredentials: true
+
+            - task: PowerShell@2
+              inputs:
+                targetType: 'inline'
+                script: |
+                  Write-Host "SourceBranch " + "$(SourceBranch)"
+                  Write-Host "TargetBranch " + "$(TargetBranch)"
+
+                  $repo = "${{ parameters.SourceRepository }}"
+                  git remote add sourcerepo $repo
+                  git remote
+
+                  $target = "$(TargetBranch)"
+                  git fetch origin $target
+                  git checkout $target
+                  git pull origin $target
+
+                  $source = "$(SourceBranch)"
+                  git fetch sourcerepo $source
+                  git pull sourcerepo $source
+
+            - task: CmdLine@2
+              inputs:
+                script: |
+                  git push
+

--- a/SampleApps/SampleApps/nuget.config
+++ b/SampleApps/SampleApps/nuget.config
@@ -2,7 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="VbsEnclaveToolingDependencies" value="https://pkgs.dev.azure.com/shine-oss/VbsEnclaveTooling/_packaging/VbsEnclaveToolingDependencies/nuget/v3/index.json" />
     <add key="localEnclaveCodeGenNuget" value="..\..\_build" />
     <add key="localEnclaveSDKNuget" value="..\..\src\VbsEnclaveSDK\_build" />
   </packageSources>

--- a/VbsEnclaveTooling.sln
+++ b/VbsEnclaveTooling.sln
@@ -44,6 +44,11 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ToolingNuget", "src\Tooling
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "veil_enclave_cpp_support_lib", "Common\veil_enclave_cpp_support_lib\veil_enclave_cpp_support_lib.vcxproj", "{26116633-98EC-4EAC-859C-139D020D10C9}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PipelineTemplates", "PipelineTemplates", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
+	ProjectSection(SolutionItems) = preProject
+		AzurePipelineTemplates\SyncMirror-Pipeline-Template.yml = AzurePipelineTemplates\SyncMirror-Pipeline-Template.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM64 = Debug|ARM64

--- a/nuget.config
+++ b/nuget.config
@@ -2,7 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="VbsEnclaveToolingDependencies" value="https://pkgs.dev.azure.com/shine-oss/VbsEnclaveTooling/_packaging/VbsEnclaveToolingDependencies/nuget/v3/index.json" />
     <add key="localEnclaveCodeGenNuget" value="_build" />
   </packageSources>
 </configuration>

--- a/src/ToolingNuget/Nuget/Microsoft.Windows.VbsEnclave.CodeGenerator.targets
+++ b/src/ToolingNuget/Nuget/Microsoft.Windows.VbsEnclave.CodeGenerator.targets
@@ -65,7 +65,7 @@
     <!-- Add enclave lib properties based on the platform. -->
     <PropertyGroup Condition="'$(Platform)'=='x64' AND '$(VbsEnclaveVirtualTrustLayer)' == 'Enclave'">
         <VC_LibraryPath_Enclave>$(VC_LibraryPath_VC_x64_Desktop)\..\$(Platform)\enclave</VC_LibraryPath_Enclave>
-        <VBS_Enclave_Dependencies Condition="'$(VBS_Enclave_Dependencies)' == ''">>$(VC_LibraryPath_Enclave)\libcmt.lib;$(VC_LibraryPath_Enclave)\libvcruntime.lib;$(winsdk_cpp_x64_root)\um\x64\vertdll.lib;$(winsdk_cpp_x64_root)\um\x64\bcrypt.lib;$(winsdk_cpp_x64_root)\ucrt_enclave\x64\ucrt.lib</VBS_Enclave_Dependencies>
+        <VBS_Enclave_Dependencies Condition="'$(VBS_Enclave_Dependencies)' == ''">$(VC_LibraryPath_Enclave)\libcmt.lib;$(VC_LibraryPath_Enclave)\libvcruntime.lib;$(winsdk_cpp_x64_root)\um\x64\vertdll.lib;$(winsdk_cpp_x64_root)\um\x64\bcrypt.lib;$(winsdk_cpp_x64_root)\ucrt_enclave\x64\ucrt.lib</VBS_Enclave_Dependencies>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Platform)'=='ARM64' AND '$(VbsEnclaveVirtualTrustLayer)' == 'Enclave'">

--- a/src/VbsEnclaveSDK/nuget.config
+++ b/src/VbsEnclaveSDK/nuget.config
@@ -2,7 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="VbsEnclaveToolingDependencies" value="https://pkgs.dev.azure.com/shine-oss/VbsEnclaveTooling/_packaging/VbsEnclaveToolingDependencies/nuget/v3/index.json" />
     <add key="localEnclaveCodeGenNuget" value="..\..\_build" />
     <add key="localEnclaveSDKNuget" value="_build" />
   </packageSources>

--- a/tests/EnclaveTests/CodeGenEndToEndTests/nuget.config
+++ b/tests/EnclaveTests/CodeGenEndToEndTests/nuget.config
@@ -2,11 +2,8 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="VbsEnclaveToolingDependencies" value="https://pkgs.dev.azure.com/shine-oss/VbsEnclaveTooling/_packaging/VbsEnclaveToolingDependencies/nuget/v3/index.json" />
     <add key="localEnclaveCodeGenNuget" value="..\..\..\_build" />
     <add key="localEnclaveSdkNuget" value="..\..\..\src\VbsEnclaveSDK\_build" />
-    
-    <!-- We'll need to create our own nuget feed but until then we can use terminals open source feed to get access to the Microsoft.Taef nuget package-->
-    <add key="TerminalDependencies" value="https://pkgs.dev.azure.com/shine-oss/terminal/_packaging/TerminalDependencies/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
### What changed
- adds sync mirror azure pipeline template to the repository. This will be used by an ADO pipeline to sync the private mirror with the public Github repo.
- Note this is the same as CSWinRT and CppWinrt's [here](https://github.com/microsoft/CsWinRT/blob/master/build/AzurePipelineTemplates/CsWinRT-SyncMirror-Pipeline.yml) and [here](https://github.com/microsoft/cppwinrt/blob/master/.pipelines/sync-mirror.yml). But replaces the branch name to sync and the repository url.
- Updates the nuget feed from using the public nuget.org feed to our own public Azure Artifact feed. 
```xml
<add key="VbsEnclaveToolingDependencies" value="https://pkgs.dev.azure.com/shine-oss/VbsEnclaveTooling/_packaging/VbsEnclaveToolingDependencies/nuget/v3/index.json" />
 ``` 
This is needed or else the 1ES pipelines will fail. (nuget.org is not allowed). Public feed [here](https://dev.azure.com/shine-oss/VbsEnclaveTooling/_artifacts/feed/VbsEnclaveToolingDependencies).
- Saw an extra `>` character in the property tag in the `VbsEnclaveTooling.sln` file and removed it to prevent build errors.

### How was this tested:
- Tested the sync mirror yaml file in private repo and confirmed private main branch gets sync'd.  See results [here](https://microsoft.visualstudio.com/Dart/_build/results?buildId=122376141&view=results)
- made sure all projects in all solutions build after feed + `>` removal.