### PR TITLE
Add build + signing azure templates for OneBranch.

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,0 +1,7 @@
+{
+    "projectName": "os",
+    "areaPath": "OS\\Windows Client and Services\\WinPD\\DFX-Developer Fundamentals and Experiences\\DevFun\\Runtime\\Security",
+    "notificationAliases": [ "vbsenclavetooling@microsoft.com" ],
+    "ignoreBranchName": true,
+    "codebaseName": "vbsenclavetooling"
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,10 @@ insert_final_newline = true
 indent_style = space 
 indent_size = 4 
 
+[*.{yml}]
+indent_style = space 
+indent_size = 2
+
 [*.{c++,cc,cpp,cppm,cxx,h,h++,hh,hpp,hxx,inl,ipp,ixx,tlh,tli}]
 
 # Visual C++ Code Style settings 

--- a/.gdn/gdnsettings
+++ b/.gdn/gdnsettings
@@ -1,0 +1,7 @@
+{
+  "files": { },
+  "folders": { },
+  "overwriteLogs": true,
+  "telemetryFlushTimeout": 10,
+  "variables": { }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -428,3 +428,15 @@ vcpkg_installed
 
 # Config
 config.overrides.props
+
+## Ignore Guardian internal files
+.r/
+rc/
+rs/
+i/
+p/
+c/
+o/
+
+## Ignore Guardian Local settings
+LocalSettings.gdn.json

--- a/AzurePipelineTemplates/OneBranch.Official.yml
+++ b/AzurePipelineTemplates/OneBranch.Official.yml
@@ -1,0 +1,53 @@
+parameters: # parameters are shown up in ADO UI in a build queue time
+- name: 'debug'
+  displayName: 'Enable debug output'
+  type: boolean
+  default: false
+
+variables:
+- template: variables/version.yml@self
+- template: variables/OneBranchVariables.yml@self
+  parameters:
+    debug: ${{ parameters.debug }}
+
+trigger: none
+
+resources:
+  repositories: 
+    - repository: templates
+      type: git
+      name: OneBranch.Pipelines/GovernedTemplates
+      ref: refs/heads/main
+
+extends:
+  template: v2/Microsoft.Official.yml@templates
+  parameters:
+    platform:     
+      name: 'windows_undocked'
+      product: 'build_tools'
+    
+    featureFlags:
+      WindowsHostVersion:
+        Version: 2022
+            
+    cloudvault:
+      enabled: false
+    
+    globalSdl:
+      isNativeCode: true
+      asyncSdl:
+        enabled: true
+      tsa:
+        enabled: true
+      codeql:
+        compiled: 
+          enabled: true
+        tsaEnabled: true
+
+    stages:
+      - template: jobs/OneBranchBuild.yml@self
+        parameters:
+          BuildConfiguration: 'release'
+          CodeGenBuildVersion: $(CodeGenBuildVersion)
+          SdkBuildVersion: $(SdkBuildVersion)
+          OfficialBuild: true

--- a/AzurePipelineTemplates/jobs/CodeGenBuildJob.yml
+++ b/AzurePipelineTemplates/jobs/CodeGenBuildJob.yml
@@ -1,0 +1,120 @@
+﻿# build file for the CodeGenerator soliution using the x64 and arm64 platforms
+parameters:
+  - name: BuildConfiguration
+    type: string
+  - name: CodeGenBuildVersion
+    type: string
+  - name: OfficialBuild
+    type: boolean
+    default: false
+jobs:
+- job: Build_and_package_CodeGen
+  displayName: 'Build CodeGen solution and nuget package'
+  pool:
+    type: windows
+  variables:
+    CodeGenSolution: $(Build.SourcesDirectory)\VbsEnclaveTooling.sln
+    VcpkgToolsDirectory: $(Build.SourcesDirectory)\src\ToolingSharedLibrary\vcpkg_installed\x64-windows-static\x64-windows\tools
+    VCPKG_ROOT: '$(Pipeline.Workspace)/vcpkg'
+    VCPKG_DEFAULT_TRIPLET: 'x64-windows'
+    NewCodeGenVersion: ${{ parameters.CodeGenBuildVersion }}
+    ob_outputDirectory: '$(Build.SourcesDirectory)\signed_nuget'   
+    ob_artifactBaseName: signed_codegen_nuget_package 
+    BaseBuildDirectory: $(Build.SourcesDirectory)\_build
+    SdkBuildDirectory: $(Build.SourcesDirectory)\src\VbsEnclaveSDK\_build
+    BuildConfiguration: ${{ parameters.BuildConfiguration }}
+
+  steps:
+    - script: |
+        git clone https://github.com/microsoft/vcpkg.git $(VCPKG_ROOT)
+      displayName: "Clone vcpkg"
+    - script: |
+        cd $(VCPKG_ROOT)
+        .\bootstrap-vcpkg.bat
+      displayName: "Bootstrap vcpkg"
+    - script: |
+        cd $(VCPKG_ROOT)
+        .\vcpkg.exe integrate install
+      displayName: "Integrate vcpkg into msbuild"
+
+    - task: UseDotNet@2
+      continueOnError: true
+      inputs: 
+        packageType: 'runtime'
+        version: '6.x'
+        performMultiLevelLookup: true
+
+    - task: NuGetCommand@2
+      displayName: NuGet restore VbsEnclaveTooling.sln
+      inputs:
+        command: 'restore'
+        restoreSolution: '$(CodeGenSolution)'
+        feedsToUse: config
+        nugetConfigPath: NuGet.config
+
+    - task: VSBuild@1
+      displayName: 'Build VbsEnclaveTooling x64'
+      inputs:
+        solution: $(CodeGenSolution)
+        msbuildArgs: /p:VbsEnclaveCodegenVersion=$(NewCodeGenVersion)
+        platform: 'x64'
+        configuration: $(BuildConfiguration)
+    
+    - task: VSBuild@1
+      displayName: Build VbsEnclaveTooling 'arm64'
+      inputs:
+        solution: $(CodeGenSolution)
+        msbuildArgs: /p:VbsEnclaveCodegenVersion=$(NewCodeGenVersion)
+        platform: 'arm64'
+        configuration: $(BuildConfiguration)
+
+    # Sign binaries in build folder
+    - task: onebranch.pipeline.signing@1
+      displayName: '🔒 Onebranch Signing for edlcodegen executable'
+      condition: eq(${{ parameters.OfficialBuild }}, 'true')
+      inputs:
+        command: sign
+        signing_profile: external_distribution
+        files_to_sign: '**/*.dll;**/*.exe'
+        search_root: $(BaseBuildDirectory)
+
+    # Sign vcpkg binaries
+    - task: onebranch.pipeline.signing@1
+      displayName: '🔒 Onebranch Signing for flatc executable'
+      condition: eq(${{ parameters.OfficialBuild }}, 'true')
+      inputs:
+        command: sign 
+        cp_code: 'CP-231522​' # OSS Third party cert
+        files_to_sign: '**/*.dll;**/*.exe' 
+        search_root: $(VcpkgToolsDirectory)
+
+    - task: NuGetToolInstaller@1
+      displayName: Use NuGet 6.0.2
+      continueOnError: True
+      inputs:
+        versionSpec: 6.0.2
+    
+    # Pack CodeGenerator nuget so SDK can access it during its build.
+    - task: NuGetCommand@2
+      displayName: 'Build CodeGenerator NuGet package'
+      inputs:
+        command: 'custom'
+        arguments: 'pack src\ToolingNuget\Nuget\Microsoft.Windows.VbsEnclave.CodeGenerator.nuspec -NonInteractive -OutputDirectory $(BaseBuildDirectory) -Properties target_version=$(NewCodeGenVersion);vbsenclave_codegen_x64_exe=$(BaseBuildDirectory)\x64\$(BuildConfiguration)\edlcodegen.exe;vcpkg_sources=$(Build.SourcesDirectory)\src\ToolingSharedLibrary\vcpkg_installed\x64-windows-static\x64-windows-static;vcpkg_tools=$(VcpkgToolsDirectory);vbsenclave_codegen_cpp_support_x64_lib=$(BaseBuildDirectory)\x64\$(BuildConfiguration)\veil_enclave_cpp_support_lib.lib;vbsenclave_codegen_cpp_support_arm64_lib=$(BaseBuildDirectory)\arm64\$(BuildConfiguration)\veil_enclave_cpp_support_lib.lib; -Version $(NewCodeGenVersion) -Verbosity Detailed'
+    
+    # Sign codegen nuget package
+    - task: onebranch.pipeline.signing@1
+      displayName: '🔒 Onebranch signing for CodeGen NuGet package'
+      condition: eq(${{ parameters.OfficialBuild }}, 'true')
+      inputs:
+        command: sign
+        cp_code: 'CP-401405' # CP-code
+        files_to_sign: 'Microsoft.Windows.VbsEnclave.*.nupkg'
+        search_root: $(BaseBuildDirectory)
+
+    # Copy signed codegen nupkg file to pipeline
+    - task: CopyFiles@2
+      displayName: Publish signed code gen nupkg file
+      inputs:
+        SourceFolder: $(BaseBuildDirectory)
+        Contents: $(BaseBuildDirectory)\Microsoft.Windows.VbsEnclave.CodeGenerator.$(NewCodeGenVersion).nupkg
+        TargetFolder: $(ob_outputDirectory)

--- a/AzurePipelineTemplates/jobs/OneBranchBuild.yml
+++ b/AzurePipelineTemplates/jobs/OneBranchBuild.yml
@@ -1,0 +1,38 @@
+parameters:
+  - name: BuildConfiguration
+    type: string
+  - name: CodeGenBuildVersion
+    type: string
+  - name: SdkBuildVersion
+    type: string
+  - name: OfficialBuild
+    type: boolean
+    default: false
+
+# Sequentially build x64 then arm64 to prevent corrupted build files when the VbsEnclaveTooling solution
+# is built with arm64. Note: when the platform is arm64 some projects get built as x64.
+stages:
+- stage: Build_codegen
+  displayName: 'Build CodeGenerator'
+  pool:
+   type: windows
+  jobs:
+    - template: CodeGenBuildJob.yml@self
+      parameters:
+        BuildConfiguration: ${{ parameters.BuildConfiguration }}
+        CodeGenBuildVersion: ${{ parameters.CodeGenBuildVersion }}
+        OfficialBuild: ${{ parameters.OfficialBuild }}
+
+- stage: Build_veil_sdk
+  displayName: 'Build SDK'
+  dependsOn: 
+    - Build_codegen
+  pool:
+    type: windows
+  jobs:
+    - template: SdkBuildJob.yml@self
+      parameters:
+        BuildConfiguration: ${{ parameters.BuildConfiguration }}
+        SdkBuildVersion:  ${{ parameters.SdkBuildVersion }}
+        CodeGenBuildVersion: ${{ parameters.CodeGenBuildVersion }}
+        OfficialBuild: ${{ parameters.OfficialBuild }}

--- a/AzurePipelineTemplates/jobs/SdkBuildJob.yml
+++ b/AzurePipelineTemplates/jobs/SdkBuildJob.yml
@@ -1,0 +1,151 @@
+﻿# build file for the veil soliution using the x64 and arm64 platforms
+parameters:
+  - name: BuildConfiguration
+    type: string
+  - name: CodeGenBuildVersion
+    type: string
+  - name: SdkBuildVersion
+    type: string
+  - name: OfficialBuild
+    type: boolean
+    default: false
+
+jobs:
+- job: Build_and_package_sdk
+  displayName: 'Build veil solution and SDK nuget package'
+  pool:
+    type: windows
+  variables:
+    SdkSolution: $(Build.SourcesDirectory)\src\VbsEnclaveSDK\vbs_enclave_implementation_library.sln
+    VeilHostVcxProj: $(Build.SourcesDirectory)\src\VbsEnclaveSDK\src\veil_host_lib\veil_host_lib.vcxproj
+    VeilHostPackageConfig: $(Build.SourcesDirectory)\src\VbsEnclaveSDK\src\veil_host_lib\packages.config
+    VeilEnclaveVcxProj: $(Build.SourcesDirectory)\src\VbsEnclaveSDK\src\veil_enclave_lib\veil_enclave_lib.vcxproj
+    VeilEnclavePackageConfig: $(Build.SourcesDirectory)\src\VbsEnclaveSDK\src\veil_enclave_lib\packages.config
+    NewCodeGenVersion: ${{ parameters.CodeGenBuildVersion }}
+    ob_outputDirectory: '$(Build.SourcesDirectory)\signed_nuget'   
+    ob_artifactBaseName: signed_sdk_nuget_package
+    BuildConfiguration: ${{ parameters.BuildConfiguration }}
+    SdkNugetPackageVersion: ${{ parameters.SdkBuildVersion }}
+    BaseBuildDirectory: $(Build.SourcesDirectory)\_build
+    SdkBuildDirectory: $(Build.SourcesDirectory)\src\VbsEnclaveSDK\_build
+
+  steps:
+   # Download the nupkg file from the codegen job
+    - task: DownloadPipelineArtifact@2
+      displayName: Download signed codeGenerator nupkg Artifact
+      inputs:
+       artifactName: 'signed_codegen_nuget_package'
+       targetPath: '$(BaseBuildDirectory)'
+
+    # Work around for Nuget restore not being able to update vcxproj projects to newer versions without the user manually updating
+    # the package.config file and updating old references in vcxproj files. Unfortunately, That feature is only supported for
+    # packages referenced via the <PackageReference /> property, which is only supported for csproj (C#) projects.
+    # See: https://developercommunity.visualstudio.com/t/use-packagereference-in-vcxproj/351636
+    - task: PowerShell@2
+      displayName: 'Update CodeGen package version in Veil Host and Enclave lib packages.config and .vcxproj'
+      inputs:
+        targetType: 'inline'
+        script: |
+          $oldCodeGenVersion = "0.0.0"
+          $CodeGenPackageId = "Microsoft.Windows.VbsEnclave.CodeGenerator"
+
+          # File paths from pipeline variables
+          $packagesConfigFiles = @( $env:VeilHostPackageConfig, $env:VeilEnclavePackageConfig )
+          Write-Host "Updating '$CodeGenPackageId' in veil enclave and host packages.config files to version: '$env:NewCodeGenVersion'"
+
+          # Update packages.config files
+          foreach ($file in $packagesConfigFiles)
+          {
+            Write-Host "Updating $file"
+            [xml]$xml = Get-Content $file
+            $packages = $xml.packages.package
+
+            foreach ($pkg in $packages)
+            {
+                if ($pkg.id -eq $CodeGenPackageId -and $pkg.version -eq $oldCodeGenVersion)
+                {
+                    $pkg.version = $env:NewCodeGenVersion
+                }
+            }
+
+            $xml.Save($file)
+            Write-Host "Updated $file successfully"
+          }
+
+          Write-Host "Updating '$CodeGenPackageId' in veil enclave and host .vcxproj files to version: '$env:NewCodeGenVersion'"
+          $oldVcxprojString = "$CodeGenPackageId.$oldCodeGenVersion"
+          $newVcxprojString   = "$CodeGenPackageId.$env:NewCodeGenVersion"
+          $vcxprojFiles = @( $env:VeilHostVcxProj, $env:VeilEnclaveVcxProj )
+
+          foreach ($file in $vcxprojFiles)
+          {
+            Write-Host "Updating $file"
+            $updated = Get-Content $file | ForEach-Object {
+                if ($_ -like "*$oldVcxprojString*")
+                {
+                    $_ -replace [regex]::Escape($oldVcxprojString), $newVcxprojString
+                } 
+                else
+                {
+                    $_
+                }
+            }
+
+            $updated | Set-Content $file
+            Write-Host "Updated $file successfully"
+          }
+
+          Write-Host "All files updated."
+
+    - task: NuGetCommand@2
+      displayName: NuGet restore vbs_enclave_implementation_library.sln
+      inputs:
+        command: 'restore'
+        restoreSolution: '$(SdkSolution)'
+        feedsToUse: config
+        nugetConfigPath: NuGet.config
+
+    - task: VSBuild@1
+      displayName: 'Build Veil Solution x64'
+      inputs:
+        solution: $(SdkSolution)
+        platform:  'x64'
+        configuration: $(BuildConfiguration)
+
+    - task: VSBuild@1
+      displayName: 'Build Veil Solution  arm64'
+      inputs:
+        solution: $(SdkSolution)
+        platform:  'arm64'
+        configuration: $(BuildConfiguration)
+
+    - task: NuGetToolInstaller@1
+      displayName: Use NuGet 6.0.2
+      continueOnError: True
+      inputs:
+        versionSpec: 6.0.2
+
+    # Pack SDK nuget package
+    - task: NuGetCommand@2
+      displayName: 'Build SDK NuGet package'
+      inputs:
+        command: 'custom'
+        arguments: 'pack src\VbsEnclaveSDK\src\veil_nuget\Nuget\Microsoft.Windows.VbsEnclave.SDK.nuspec -NonInteractive -OutputDirectory $(BaseBuildDirectory) -Properties target_version=$(SdkNugetPackageVersion);vbsenclave_sdk_enclave_x64_lib=$(SdkBuildDirectory)\x64\$(BuildConfiguration)\veil_enclave_lib.lib;vbsenclave_sdk_enclave_arm64_lib=$(SdkBuildDirectory)\arm64\$(BuildConfiguration)\veil_enclave_lib.lib;vbsenclave_sdk_host_x64_lib=$(SdkBuildDirectory)\x64\$(BuildConfiguration)\veil_host_lib\veil_host_lib.lib;vbsenclave_sdk_host_arm64_lib=$(SdkBuildDirectory)\arm64\$(BuildConfiguration)\veil_host_lib\veil_host_lib.lib;vbsenclave_sdk_cpp_support_x64_lib=$(SdkBuildDirectory)\x64\$(BuildConfiguration)\veil_enclave_cpp_support_lib.lib;vbsenclave_sdk_cpp_support_arm64_lib=$(SdkBuildDirectory)\arm64\$(BuildConfiguration)\veil_enclave_cpp_support_lib.lib; -Version $(SdkNugetPackageVersion) -Verbosity Detailed'
+
+    # Sign sdk nuget package
+    - task: onebranch.pipeline.signing@1
+      displayName: '🔒 Onebranch signing for SDK NuGet package'
+      condition: eq(${{ parameters.OfficialBuild }}, 'true')
+      inputs:
+        command: sign
+        cp_code: 'CP-401405' # CP-code
+        files_to_sign: 'Microsoft.Windows.VbsEnclave.*.nupkg'
+        search_root: $(BaseBuildDirectory)
+
+    # Copy signed sdk nupkg file to pipeline
+    - task: CopyFiles@2
+      displayName: publish signed SDK nupkg file
+      inputs:
+        SourceFolder: $(BaseBuildDirectory)
+        Contents: $(BaseBuildDirectory)\Microsoft.Windows.VbsEnclave.SDK.$(SdkNugetPackageVersion).nupkg
+        TargetFolder: $(ob_outputDirectory)

--- a/AzurePipelineTemplates/variables/OneBranchVariables.yml
+++ b/AzurePipelineTemplates/variables/OneBranchVariables.yml
@@ -1,0 +1,16 @@
+parameters:
+- name: 'debug'
+  displayName: 'Enable debug output'
+  type: boolean
+  default: false
+
+variables:
+  system.debug: ${{ parameters.debug }}
+  ENABLE_PRS_DELAYSIGN: 1
+  NUGET_XMLDOC_MODE: none
+
+  # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest' 
+
+  Codeql.Enabled: true #  CodeQL once every 3 days on the default branch for all languages its applicable to in that pipeline.
+  GDN_USE_DOTNET: true

--- a/AzurePipelineTemplates/variables/version.yml
+++ b/AzurePipelineTemplates/variables/version.yml
@@ -1,0 +1,37 @@
+variables:
+- name: VersionDate
+  value: "$[format('{0:yyMMdd}', pipeline.startTime)]"
+- name: VersionCounter
+  value: "$[counter(variables['VersionDate'], 1)]"
+
+# CodeGen versioning info
+- name: CodeGenMajorVersion
+  value: "0"
+- name: CodeGenMinorVersion
+  value: "0"
+- name: CodeGenPatchVersion
+  value: "1"
+
+
+# SDK versioning info
+- name: SdkMajorVersion
+  value: "0"
+- name: SdkMinorVersion
+  value: "0"
+- name: SdkPatchVersion
+  value: "1"
+
+
+# Conditionally set values if branch name starts with 'prerelease'
+- ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/prerelease/') }}:
+    - name: CodeGenBuildVersion
+      value: $(CodeGenMajorVersion).$(CodeGenMinorVersion).$(CodeGenPatchVersion)-prerelease.$(VersionDate).$(VersionCounter)
+    - name: SdkBuildVersion
+      value: $(SdkMajorVersion).$(SdkMinorVersion).$(SdkPatchVersion)-prerelease.$(VersionDate).$(VersionCounter)
+
+# Don't add prerelease if branch name doesn't start with 'prerelease'
+- ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/heads/prerelease/')) }}:
+    - name: CodeGenBuildVersion
+      value: $(CodeGenMajorVersion).$(CodeGenMinorVersion).$(CodeGenPatchVersion)
+    - name: SdkBuildVersion
+      value: $(SdkMajorVersion).$(SdkMinorVersion).$(SdkPatchVersion)

--- a/VbsEnclaveTooling.sln
+++ b/VbsEnclaveTooling.sln
@@ -46,7 +46,27 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "veil_enclave_cpp_support_li
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PipelineTemplates", "PipelineTemplates", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
 	ProjectSection(SolutionItems) = preProject
+		AzurePipelineTemplates\OneBranch.Official.yml = AzurePipelineTemplates\OneBranch.Official.yml
 		AzurePipelineTemplates\SyncMirror-Pipeline-Template.yml = AzurePipelineTemplates\SyncMirror-Pipeline-Template.yml
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "jobs", "jobs", "{D2331F9A-86B9-4308-B8B7-994114A65122}"
+	ProjectSection(SolutionItems) = preProject
+		AzurePipelineTemplates\jobs\CodeGenBuildJob.yml = AzurePipelineTemplates\jobs\CodeGenBuildJob.yml
+		AzurePipelineTemplates\jobs\OneBranchBuild.yml = AzurePipelineTemplates\jobs\OneBranchBuild.yml
+		AzurePipelineTemplates\jobs\SdkBuildJob.yml = AzurePipelineTemplates\jobs\SdkBuildJob.yml
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "variables", "variables", "{B4BB7018-CEC4-41C6-BBBD-925A69D5032A}"
+	ProjectSection(SolutionItems) = preProject
+		AzurePipelineTemplates\variables\OneBranchVariables.yml = AzurePipelineTemplates\variables\OneBranchVariables.yml
+		AzurePipelineTemplates\variables\version.yml = AzurePipelineTemplates\variables\version.yml
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "settings", "settings", "{9D71BE1B-2375-490F-9F24-7EDF81094461}"
+	ProjectSection(SolutionItems) = preProject
+		.gdn\gdnsettings = .gdn\gdnsettings
+		.config\tsaoptions.json = .config\tsaoptions.json
 	EndProjectSection
 EndProject
 Global
@@ -100,6 +120,11 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{D2331F9A-86B9-4308-B8B7-994114A65122} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{B4BB7018-CEC4-41C6-BBBD-925A69D5032A} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{9D71BE1B-2375-490F-9F24-7EDF81094461} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {166D23FF-1362-43F2-BEE7-58FDCDB133DF}


### PR DESCRIPTION
### What Changed
- Adds new Azure pipeline templates that can be ran in OneBranch to generate and sign our binaries and our nuget packages 
- The structure is mostly inspired from reading the [eng docs](https://eng.ms/docs/products/onebranch/), and looking through how `cppwinrt` and `cswinrt` repos do theirs.
- The data in `.gdn/gdnsettings`, `.config/tsaoptions.json` are used by the pipelines. Tsaoptions is used to submit bugs found during a pipeline run. See cppWinrt's [here](https://github.com/microsoft/cppwinrt/blob/master/.config/tsaoptions.json) that includes areapath to submit the bugs.
- Versioning for the nuget packages come from the `variables/OneBranchVariables.yml` file. If the branch that runs the pipeline starts with the prefix `prerelease/` then the nuget package version will have `-prerelease-MMDDYY.<rev num>` appended to the end. If it does not have the prefix then it will only have the `Major.Minor.Patch` version.
-  `OneBranchBuild.yml` is the yaml file that contains the stages that will start the `CodeGenBuildJob` and the `SdkBuildJob`. 
- The `CodeGenBuildJob` will build the `x64` and `arm64` versions of the `vbsenclavetooling codegen` solution, sign the `edlcodegen` and `flatc` executables and lastly create and sign the `nupkg` file.
- The `SdkBuildJob` will build the `x64` and `arm64` versions of the `veil sdk` solution,  and lastly create and sign the `nupkg` file. 
- Both  `CodeGenBuildJob` and the `SdkBuildJob` jobs publish their signed nuget packages as pipeline `artifiacts` user `signed_codegen_nuget_package` and `signed_sdk_nuget_package` respectively.

## How was it tested
- You can only run official prod pipelines using commits that have been consumed via a pull request. So, to test I used a non prod pipeline. See the result all passing [here](https://dev.azure.com/microsoft/Dart/_build/results?buildId=122643089&view=results) 
- The only thing that is different in this commit versus the one I did in the non prod pipeline is the template our `OneBranch.Official.yml` template extends. I updated this to use the `template: v2/Microsoft.Official.yml@templates` and not the non prod one.
- Ultimately there could still be something that fails in the prod one and not in the non-prod one, but I am at least confident the contents of these yml files build both solutions for x64 and arm64. Signing `nupkg` files and third party binaries (`flatc.exe`) will only happen in a prod pipeline. The `edlcodegen.exe` file gets signed in both prod and non prod pipelines since it is produced by us, although non-prod pipelines just test sign it.