### PR TITLE
use repositories list and -checkout instead of git clone directory for prod pipeline

### DIFF
--- a/AzurePipelineTemplates/OneBranch.Official.yml
+++ b/AzurePipelineTemplates/OneBranch.Official.yml
@@ -18,6 +18,13 @@ resources:
       type: git
       name: OneBranch.Pipelines/GovernedTemplates
       ref: refs/heads/main
+    
+    - repository: Vcpkg
+      type: github
+      name: microsoft/vcpkg
+      endpoint: microsoft
+      ref: refs/heads/master
+      trigger: none
 
 extends:
   template: v2/Microsoft.Official.yml@templates

--- a/AzurePipelineTemplates/jobs/CodeGenBuildJob.yml
+++ b/AzurePipelineTemplates/jobs/CodeGenBuildJob.yml
@@ -26,7 +26,7 @@ jobs:
 
   steps:
     - checkout: Vcpkg
-      path: $(VCPKG_ROOT)
+      path: 's\vcpkg'
       displayName: "Checkout Vcpkg"
     - script: |
         cd $(VCPKG_ROOT)

--- a/AzurePipelineTemplates/jobs/CodeGenBuildJob.yml
+++ b/AzurePipelineTemplates/jobs/CodeGenBuildJob.yml
@@ -15,7 +15,7 @@ jobs:
   variables:
     CodeGenSolution: $(Build.SourcesDirectory)\VbsEnclaveTooling.sln
     VcpkgToolsDirectory: $(Build.SourcesDirectory)\src\ToolingSharedLibrary\vcpkg_installed\x64-windows-static\x64-windows\tools
-    VCPKG_ROOT: '$(Pipeline.Workspace)/vcpkg'
+    VCPKG_ROOT: '$(Pipeline.Workspace)\s\vcpkg'
     VCPKG_DEFAULT_TRIPLET: 'x64-windows'
     NewCodeGenVersion: ${{ parameters.CodeGenBuildVersion }}
     ob_outputDirectory: '$(Build.SourcesDirectory)\signed_nuget'   
@@ -25,9 +25,9 @@ jobs:
     BuildConfiguration: ${{ parameters.BuildConfiguration }}
 
   steps:
-    - script: |
-        git clone https://github.com/microsoft/vcpkg.git $(VCPKG_ROOT)
-      displayName: "Clone vcpkg"
+    - checkout: Vcpkg
+      path: $(VCPKG_ROOT)
+      displayName: "Checkout Vcpkg"
     - script: |
         cd $(VCPKG_ROOT)
         .\bootstrap-vcpkg.bat


### PR DESCRIPTION
- prod one branch pipelines don't allow using git clone directly, but non prod one branch ones do. So I updated the repositories list to include vcpkg and instead of using `git clone` I used `-checkout`. 