### PR TITLE
Add release pipeline

### DIFF
--- a/AzurePipelineTemplates/jobs/PublishNugetPackages.yml
+++ b/AzurePipelineTemplates/jobs/PublishNugetPackages.yml
@@ -1,0 +1,48 @@
+resources:
+  repositories:
+  - repository: templates
+    type: git
+    name: OneBranch.Pipelines/GovernedTemplates
+    ref: refs/heads/main
+  pipelines:
+  # Reference pipeline that created the signed nupkg artifacts so we can consume them later
+  - pipeline: VbsEnclaveTooling 
+    source: 'Vbs Enclave Tooling OneBranch (Official)'
+    trigger: none
+
+extends:
+  template: v2/OneBranch.Official.CrossPlat.yml@templates
+  parameters:
+    release:
+      category: NonAzure
+
+    stages:
+    - stage: 'Publish'  
+      displayName: 'Publish to NuGet'
+      variables:
+        ob_release_environment: Production
+        
+      jobs:
+      - job: ReleaseToNugetOrg
+        pool:
+          type: release
+        variables:
+          ob_nugetPublishing_enabled: true
+        templateContext:
+          inputs:
+          - input: pipelineArtifact
+            pipeline: VbsEnclaveTooling
+            artifactName: signed_codegen_nuget_package
+
+          - input: pipelineArtifact
+            pipeline: VbsEnclaveTooling
+            artifactName: signed_sdk_nuget_package
+
+        steps:
+        - task: NuGetCommand@2
+          displayName: 'Push CodeGenerator and SDK nuget packages to nuget.org'
+          inputs:
+            command: push
+            packagesToPush: '$(Pipeline.Workspace)\Microsoft.Windows.VbsEnclave.*.nupkg'
+            nuGetFeedType: external
+            publishFeedCredentials: 'VbsEnclaveTooling Nuget' # Service connection

--- a/VbsEnclaveTooling.sln
+++ b/VbsEnclaveTooling.sln
@@ -54,6 +54,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "jobs", "jobs", "{D2331F9A-8
 	ProjectSection(SolutionItems) = preProject
 		AzurePipelineTemplates\jobs\CodeGenBuildJob.yml = AzurePipelineTemplates\jobs\CodeGenBuildJob.yml
 		AzurePipelineTemplates\jobs\OneBranchBuild.yml = AzurePipelineTemplates\jobs\OneBranchBuild.yml
+		AzurePipelineTemplates\jobs\PublishNugetPackages.yml = AzurePipelineTemplates\jobs\PublishNugetPackages.yml
 		AzurePipelineTemplates\jobs\SdkBuildJob.yml = AzurePipelineTemplates\jobs\SdkBuildJob.yml
 	EndProjectSection
 EndProject


### PR DESCRIPTION
### What changed
This PR adds an azure pipeline template that publishes our nuget packages that were build in OneBranch to nuget.org.

 - This is pretty much exactly what Cs/WinRT does in their [release pipeline](https://github.com/microsoft/CsWinRT/blob/master/build/AzurePipelineTemplates/CsWinRT-Release.yml)

### How was this tested
- You an approval in the approval service dashboard to run a prod release pipeline. So, instead I used a non prod release pipeline that used this same template but instead published the packages to an internal nuget feed. You can see the results [here](https://microsoft.visualstudio.com/Dart/_build/results?buildId=122748896&view=results) and the packages in the internal feed [here](https://microsoft.visualstudio.com/Dart/_artifacts/feed/VbsEnclaveTooling.Private). 
    - Only things that I changed were:
        - `ob_release_environment` was equal to `Test` instead of `Production`
        - `nuGetFeedType` was equal to `internal` instead of `external`
        - For internal feeds you have to use the `publishVstsFeed` option with the name of the internal nuget feed as the value. For external feeds you use the `publishFeedCredentials` option with the name of the service connection that will be used to authenticate with nuget.org. See [NuGetCommand@2](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/nuget-command-v2?view=azure-pipelines)
- Note: I created a service connection called [VbsEnclaveTooling Nuget](https://microsoft.visualstudio.com/Dart/_settings/adminservices?resourceId=95fbd8cb-0cfd-4bbc-83a9-5d763f98bc8c)  that contains the key needed for us to authenticate with nuget.org when the pipeline runs.