### PR TITLE
Update to allow projects that consume static libs from our nuget packages to be built with release and debug

### DIFF
--- a/AzurePipelineTemplates/OneBranch.Official.yml
+++ b/AzurePipelineTemplates/OneBranch.Official.yml
@@ -54,7 +54,6 @@ extends:
     stages:
       - template: jobs/OneBranchBuild.yml@self
         parameters:
-          BuildConfiguration: 'release'
           CodeGenBuildVersion: $(CodeGenBuildVersion)
           SdkBuildVersion: $(SdkBuildVersion)
           OfficialBuild: true

--- a/AzurePipelineTemplates/OneBranch.Official.yml
+++ b/AzurePipelineTemplates/OneBranch.Official.yml
@@ -50,7 +50,7 @@ extends:
         compiled: 
           enabled: true
         tsaEnabled: true
-
+      
     stages:
       - template: jobs/OneBranchBuild.yml@self
         parameters:

--- a/AzurePipelineTemplates/jobs/CodeGenBuildJob.yml
+++ b/AzurePipelineTemplates/jobs/CodeGenBuildJob.yml
@@ -28,14 +28,14 @@ jobs:
     Arm64DebugBuildLocation: $(BaseBuildDirectory)\ARM64\Debug
 
     # veil_cpp_support_lib pack args
-    VeilCppSuportLibX64Release: vbsenclave_codegen_cpp_support_x64_Release_lib=$(x64ReleaseBuildLocation)\veil_cpp_support_x64_Release_lib.lib
-    VeilCppSuportPdbX64Release: vbsenclave_codegen_cpp_support_x64_Release_pdb=$(x64ReleaseBuildLocation)\veil_cpp_support_x64_Release_lib.pdb
-    VeilCppSuportLibX64Debug: vbsenclave_codegen_cpp_support_x64_Debug_lib=$(x64DebugBuildLocation)\veil_cpp_support_x64_Debug_lib.lib
-    VeilCppSuportPdbX64Debug: vbsenclave_codegen_cpp_support_x64_Debug_pdb=$(x64DebugBuildLocation)\veil_cpp_support_x64_Debug_lib.pdb
-    VeilCppSuportLibARM64Release: vbsenclave_codegen_cpp_support_ARM64_Release_lib=$(Arm64ReleaseBuildLocation)\veil_cpp_support_ARM64_Release_lib.lib
-    VeilCppSuportPdbARM64Release: vbsenclave_codegen_cpp_support_ARM64_Release_pdb=$(Arm64ReleaseBuildLocation)\veil_cpp_support_ARM64_Release_pdb.pdb
-    VeilCppSuportLibARM64Debug: vbsenclave_codegen_cpp_support_ARM64_Debug_lib=$(Arm64DebugBuildLocation)\veil_cpp_support_ARM64_Debug_lib.lib
-    VeilCppSuportPdbARM64Debug: vbsenclave_codegen_cpp_support_ARM64_Debug_pdb=$(Arm64DebugBuildLocation)\veil_cpp_support_ARM64_Debug_lib.pdb
+    VeilCppSupportLibX64Release: vbsenclave_codegen_cpp_support_x64_Release_lib=$(x64ReleaseBuildLocation)\veil_cpp_support_x64_Release_lib.lib
+    VeilCppSupportPdbX64Release: vbsenclave_codegen_cpp_support_x64_Release_pdb=$(x64ReleaseBuildLocation)\veil_cpp_support_x64_Release_lib.pdb
+    VeilCppSupportLibX64Debug: vbsenclave_codegen_cpp_support_x64_Debug_lib=$(x64DebugBuildLocation)\veil_cpp_support_x64_Debug_lib.lib
+    VeilCppSupportPdbX64Debug: vbsenclave_codegen_cpp_support_x64_Debug_pdb=$(x64DebugBuildLocation)\veil_cpp_support_x64_Debug_lib.pdb
+    VeilCppSupportLibARM64Release: vbsenclave_codegen_cpp_support_ARM64_Release_lib=$(Arm64ReleaseBuildLocation)\veil_cpp_support_ARM64_Release_lib.lib
+    VeilCppSupportPdbARM64Release: vbsenclave_codegen_cpp_support_ARM64_Release_pdb=$(Arm64ReleaseBuildLocation)\veil_cpp_support_ARM64_Release_pdb.pdb
+    VeilCppSupportLibARM64Debug: vbsenclave_codegen_cpp_support_ARM64_Debug_lib=$(Arm64DebugBuildLocation)\veil_cpp_support_ARM64_Debug_lib.lib
+    VeilCppSupportPdbARM64Debug: vbsenclave_codegen_cpp_support_ARM64_Debug_pdb=$(Arm64DebugBuildLocation)\veil_cpp_support_ARM64_Debug_lib.pdb
     
   steps:
     - checkout: Vcpkg
@@ -128,7 +128,7 @@ jobs:
       displayName: 'Build CodeGenerator NuGet package'
       inputs:
         command: 'custom'
-        arguments: 'pack src\ToolingNuget\Nuget\Microsoft.Windows.VbsEnclave.CodeGenerator.nuspec -NonInteractive -OutputDirectory $(BaseBuildDirectory) -Properties target_version=$(NewCodeGenVersion);vbsenclave_codegen_x64_exe=$(x64ReleaseBuildLocation)\edlcodegen.exe;vcpkg_sources=$(VcpkgSourcesDirectory);vcpkg_tools=$(VcpkgToolsDirectory);$(VeilCppSuportLibX64Release);$(VeilCppSuportLibX64Debug);$(VeilCppSuportLibARM64Release);$(VeilCppSuportLibARM64Debug);$(VeilCppSuportPdbX64Release);$(VeilCppSuportPdbX64Debug);$(VeilCppSuportPdbARM64Release);$(VeilCppSuportPdbARM64Debug)  -Version $(NewCodeGenVersion) -Verbosity Detailed'
+        arguments: 'pack src\ToolingNuget\Nuget\Microsoft.Windows.VbsEnclave.CodeGenerator.nuspec -NonInteractive -OutputDirectory $(BaseBuildDirectory) -Properties target_version=$(NewCodeGenVersion);vbsenclave_codegen_x64_exe=$(x64ReleaseBuildLocation)\edlcodegen.exe;vcpkg_sources=$(VcpkgSourcesDirectory);vcpkg_tools=$(VcpkgToolsDirectory);$(VeilCppSupportLibX64Release);$(VeilCppSupportLibX64Debug);$(VeilCppSupportLibARM64Release);$(VeilCppSupportLibARM64Debug);$(VeilCppSupportPdbX64Release);$(VeilCppSupportPdbX64Debug);$(VeilCppSupportPdbARM64Release);$(VeilCppSupportPdbARM64Debug)  -Version $(NewCodeGenVersion) -Verbosity Detailed'
     
     # Sign codegen nuget package
     - task: onebranch.pipeline.signing@1

--- a/AzurePipelineTemplates/jobs/CodeGenBuildJob.yml
+++ b/AzurePipelineTemplates/jobs/CodeGenBuildJob.yml
@@ -1,7 +1,5 @@
 ﻿# build file for the CodeGenerator soliution using the x64 and arm64 platforms
 parameters:
-  - name: BuildConfiguration
-    type: string
   - name: CodeGenBuildVersion
     type: string
   - name: OfficialBuild
@@ -15,14 +13,24 @@ jobs:
   variables:
     CodeGenSolution: $(Build.SourcesDirectory)\VbsEnclaveTooling.sln
     VcpkgToolsDirectory: $(Build.SourcesDirectory)\src\ToolingSharedLibrary\vcpkg_installed\x64-windows-static\x64-windows\tools
+    VcpkgSourcesDirectory: $(Build.SourcesDirectory)\src\ToolingSharedLibrary\vcpkg_installed\x64-windows-static\x64-windows-static
     VCPKG_ROOT: '$(Pipeline.Workspace)\s\vcpkg'
     VCPKG_DEFAULT_TRIPLET: 'x64-windows'
     NewCodeGenVersion: ${{ parameters.CodeGenBuildVersion }}
     ob_outputDirectory: '$(Build.SourcesDirectory)\signed_nuget'   
     ob_artifactBaseName: signed_codegen_nuget_package 
     BaseBuildDirectory: $(Build.SourcesDirectory)\_build
-    SdkBuildDirectory: $(Build.SourcesDirectory)\src\VbsEnclaveSDK\_build
     BuildConfiguration: ${{ parameters.BuildConfiguration }}
+    x64ReleaseBuildLocation: $(BaseBuildDirectory)\x64\Release
+    x64DebugBuildLocation: $(BaseBuildDirectory)\x64\Debug
+    Arm64ReleaseBuildLocation: $(BaseBuildDirectory)\ARM64\Release
+    Arm64DebugBuildLocation: $(BaseBuildDirectory)\ARM64\Debug
+
+    # veil_cpp_support_lib pack args
+    VeilCppSuportLibX64Release: vbsenclave_codegen_cpp_support_x64_Release_lib=$(x64ReleaseBuildLocation)\veil_cpp_support_x64_Release_lib.lib  
+    VeilCppSuportLibX64Debug: vbsenclave_codegen_cpp_support_x64_Debug_lib=$(x64DebugBuildLocation)\veil_cpp_support_x64_Debug_lib.lib
+    VeilCppSuportLibARM64Release: vbsenclave_codegen_cpp_support_ARM64_Release_lib=$(Arm64ReleaseBuildLocation)\veil_cpp_support_ARM64_Release_lib
+    VeilCppSuportLibARM64Debug: vbsenclave_codegen_cpp_support_ARM64_Debug_lib=$(Arm64DebugBuildLocation)\veil_cpp_support_ARM64_Debug_lib
 
   steps:
     - checkout: Vcpkg
@@ -53,20 +61,36 @@ jobs:
         nugetConfigPath: NuGet.config
 
     - task: VSBuild@1
-      displayName: 'Build VbsEnclaveTooling x64'
+      displayName: Build VbsEnclaveTooling x64 release
       inputs:
         solution: $(CodeGenSolution)
         msbuildArgs: /p:VbsEnclaveCodegenVersion=$(NewCodeGenVersion)
         platform: 'x64'
-        configuration: $(BuildConfiguration)
+        configuration: 'Release'
     
     - task: VSBuild@1
-      displayName: Build VbsEnclaveTooling 'arm64'
+      displayName: Build VbsEnclaveTooling arm64 release
       inputs:
         solution: $(CodeGenSolution)
         msbuildArgs: /p:VbsEnclaveCodegenVersion=$(NewCodeGenVersion)
         platform: 'arm64'
-        configuration: $(BuildConfiguration)
+        configuration: 'Release'
+
+    - task: VSBuild@1
+      displayName: Build VbsEnclaveTooling x64 debug
+      inputs:
+        solution: $(CodeGenSolution)
+        msbuildArgs: /p:VbsEnclaveCodegenVersion=$(NewCodeGenVersion)
+        platform: 'x64'
+        configuration: 'Debug'
+    
+    - task: VSBuild@1
+      displayName: Build VbsEnclaveTooling arm64 debug
+      inputs:
+        solution: $(CodeGenSolution)
+        msbuildArgs: /p:VbsEnclaveCodegenVersion=$(NewCodeGenVersion)
+        platform: 'arm64'
+        configuration: 'Debug'
 
     # Sign binaries in build folder
     - task: onebranch.pipeline.signing@1
@@ -99,7 +123,7 @@ jobs:
       displayName: 'Build CodeGenerator NuGet package'
       inputs:
         command: 'custom'
-        arguments: 'pack src\ToolingNuget\Nuget\Microsoft.Windows.VbsEnclave.CodeGenerator.nuspec -NonInteractive -OutputDirectory $(BaseBuildDirectory) -Properties target_version=$(NewCodeGenVersion);vbsenclave_codegen_x64_exe=$(BaseBuildDirectory)\x64\$(BuildConfiguration)\edlcodegen.exe;vcpkg_sources=$(Build.SourcesDirectory)\src\ToolingSharedLibrary\vcpkg_installed\x64-windows-static\x64-windows-static;vcpkg_tools=$(VcpkgToolsDirectory);vbsenclave_codegen_cpp_support_x64_lib=$(BaseBuildDirectory)\x64\$(BuildConfiguration)\veil_enclave_cpp_support_lib.lib;vbsenclave_codegen_cpp_support_arm64_lib=$(BaseBuildDirectory)\arm64\$(BuildConfiguration)\veil_enclave_cpp_support_lib.lib; -Version $(NewCodeGenVersion) -Verbosity Detailed'
+        arguments: 'pack src\ToolingNuget\Nuget\Microsoft.Windows.VbsEnclave.CodeGenerator.nuspec -NonInteractive -OutputDirectory $(BaseBuildDirectory) -Properties target_version=$(NewCodeGenVersion);vbsenclave_codegen_x64_exe=$(x64ReleaseBuildLocation)\edlcodegen.exe;vcpkg_sources=$(VcpkgSourcesDirectory);vcpkg_tools=$(VcpkgToolsDirectory);$(VeilCppSuportLibX64Release);$(VeilCppSuportLibX64Debug);$(VeilCppSuportLibARM64Release);$(VeilCppSuportLibARM64Debug)  -Version $(NewCodeGenVersion) -Verbosity Detailed'
     
     # Sign codegen nuget package
     - task: onebranch.pipeline.signing@1

--- a/AzurePipelineTemplates/jobs/CodeGenBuildJob.yml
+++ b/AzurePipelineTemplates/jobs/CodeGenBuildJob.yml
@@ -12,8 +12,9 @@ jobs:
     type: windows
   variables:
     CodeGenSolution: $(Build.SourcesDirectory)\VbsEnclaveTooling.sln
-    VcpkgToolsDirectory: $(Build.SourcesDirectory)\src\ToolingSharedLibrary\vcpkg_installed\x64-windows-static\x64-windows\tools
-    VcpkgSourcesDirectory: $(Build.SourcesDirectory)\src\ToolingSharedLibrary\vcpkg_installed\x64-windows-static\x64-windows-static
+    VcpkgDirectory: $(Build.SourcesDirectory)\src\ToolingSharedLibrary\vcpkg_installed\x64-windows-static\x64-windows
+    VcpkgToolsDirectory: $(VcpkgDirectory)\x64-windows\tools
+    VcpkgSourcesDirectory: $(VcpkgDirectory)\x64-windows-static
     VCPKG_ROOT: '$(Pipeline.Workspace)\s\vcpkg'
     VCPKG_DEFAULT_TRIPLET: 'x64-windows'
     NewCodeGenVersion: ${{ parameters.CodeGenBuildVersion }}
@@ -32,7 +33,7 @@ jobs:
     VeilCppSuportLibX64Debug: vbsenclave_codegen_cpp_support_x64_Debug_lib=$(x64DebugBuildLocation)\veil_cpp_support_x64_Debug_lib.lib
     VeilCppSuportPdbX64Debug: vbsenclave_codegen_cpp_support_x64_Debug_pdb=$(x64DebugBuildLocation)\veil_cpp_support_x64_Debug_lib.pdb
     VeilCppSuportLibARM64Release: vbsenclave_codegen_cpp_support_ARM64_Release_lib=$(Arm64ReleaseBuildLocation)\veil_cpp_support_ARM64_Release_lib.lib
-    VeilCppSuportPdbARM64Release: vbsenclave_codegen_cpp_support_ARM64_Release_lib=$(Arm64ReleaseBuildLocation)\veil_cpp_support_ARM64_Release_pdb.pdb
+    VeilCppSuportPdbARM64Release: vbsenclave_codegen_cpp_support_ARM64_Release_pdb=$(Arm64ReleaseBuildLocation)\veil_cpp_support_ARM64_Release_pdb.pdb
     VeilCppSuportLibARM64Debug: vbsenclave_codegen_cpp_support_ARM64_Debug_lib=$(Arm64DebugBuildLocation)\veil_cpp_support_ARM64_Debug_lib.lib
     VeilCppSuportPdbARM64Debug: vbsenclave_codegen_cpp_support_ARM64_Debug_pdb=$(Arm64DebugBuildLocation)\veil_cpp_support_ARM64_Debug_lib.pdb
     

--- a/AzurePipelineTemplates/jobs/CodeGenBuildJob.yml
+++ b/AzurePipelineTemplates/jobs/CodeGenBuildJob.yml
@@ -27,11 +27,15 @@ jobs:
     Arm64DebugBuildLocation: $(BaseBuildDirectory)\ARM64\Debug
 
     # veil_cpp_support_lib pack args
-    VeilCppSuportLibX64Release: vbsenclave_codegen_cpp_support_x64_Release_lib=$(x64ReleaseBuildLocation)\veil_cpp_support_x64_Release_lib.lib  
+    VeilCppSuportLibX64Release: vbsenclave_codegen_cpp_support_x64_Release_lib=$(x64ReleaseBuildLocation)\veil_cpp_support_x64_Release_lib.lib
+    VeilCppSuportPdbX64Release: vbsenclave_codegen_cpp_support_x64_Release_pdb=$(x64ReleaseBuildLocation)\veil_cpp_support_x64_Release_lib.pdb
     VeilCppSuportLibX64Debug: vbsenclave_codegen_cpp_support_x64_Debug_lib=$(x64DebugBuildLocation)\veil_cpp_support_x64_Debug_lib.lib
-    VeilCppSuportLibARM64Release: vbsenclave_codegen_cpp_support_ARM64_Release_lib=$(Arm64ReleaseBuildLocation)\veil_cpp_support_ARM64_Release_lib
-    VeilCppSuportLibARM64Debug: vbsenclave_codegen_cpp_support_ARM64_Debug_lib=$(Arm64DebugBuildLocation)\veil_cpp_support_ARM64_Debug_lib
-
+    VeilCppSuportPdbX64Debug: vbsenclave_codegen_cpp_support_x64_Debug_pdb=$(x64DebugBuildLocation)\veil_cpp_support_x64_Debug_lib.pdb
+    VeilCppSuportLibARM64Release: vbsenclave_codegen_cpp_support_ARM64_Release_lib=$(Arm64ReleaseBuildLocation)\veil_cpp_support_ARM64_Release_lib.lib
+    VeilCppSuportPdbARM64Release: vbsenclave_codegen_cpp_support_ARM64_Release_lib=$(Arm64ReleaseBuildLocation)\veil_cpp_support_ARM64_Release_pdb.pdb
+    VeilCppSuportLibARM64Debug: vbsenclave_codegen_cpp_support_ARM64_Debug_lib=$(Arm64DebugBuildLocation)\veil_cpp_support_ARM64_Debug_lib.lib
+    VeilCppSuportPdbARM64Debug: vbsenclave_codegen_cpp_support_ARM64_Debug_pdb=$(Arm64DebugBuildLocation)\veil_cpp_support_ARM64_Debug_lib.pdb
+    
   steps:
     - checkout: Vcpkg
       path: 's\vcpkg'
@@ -123,7 +127,7 @@ jobs:
       displayName: 'Build CodeGenerator NuGet package'
       inputs:
         command: 'custom'
-        arguments: 'pack src\ToolingNuget\Nuget\Microsoft.Windows.VbsEnclave.CodeGenerator.nuspec -NonInteractive -OutputDirectory $(BaseBuildDirectory) -Properties target_version=$(NewCodeGenVersion);vbsenclave_codegen_x64_exe=$(x64ReleaseBuildLocation)\edlcodegen.exe;vcpkg_sources=$(VcpkgSourcesDirectory);vcpkg_tools=$(VcpkgToolsDirectory);$(VeilCppSuportLibX64Release);$(VeilCppSuportLibX64Debug);$(VeilCppSuportLibARM64Release);$(VeilCppSuportLibARM64Debug)  -Version $(NewCodeGenVersion) -Verbosity Detailed'
+        arguments: 'pack src\ToolingNuget\Nuget\Microsoft.Windows.VbsEnclave.CodeGenerator.nuspec -NonInteractive -OutputDirectory $(BaseBuildDirectory) -Properties target_version=$(NewCodeGenVersion);vbsenclave_codegen_x64_exe=$(x64ReleaseBuildLocation)\edlcodegen.exe;vcpkg_sources=$(VcpkgSourcesDirectory);vcpkg_tools=$(VcpkgToolsDirectory);$(VeilCppSuportLibX64Release);$(VeilCppSuportLibX64Debug);$(VeilCppSuportLibARM64Release);$(VeilCppSuportLibARM64Debug);$(VeilCppSuportPdbX64Release);$(VeilCppSuportPdbX64Debug);$(VeilCppSuportPdbARM64Release);$(VeilCppSuportPdbARM64Debug)  -Version $(NewCodeGenVersion) -Verbosity Detailed'
     
     # Sign codegen nuget package
     - task: onebranch.pipeline.signing@1

--- a/AzurePipelineTemplates/jobs/OneBranchBuild.yml
+++ b/AzurePipelineTemplates/jobs/OneBranchBuild.yml
@@ -1,6 +1,4 @@
 parameters:
-  - name: BuildConfiguration
-    type: string
   - name: CodeGenBuildVersion
     type: string
   - name: SdkBuildVersion
@@ -19,7 +17,6 @@ stages:
   jobs:
     - template: CodeGenBuildJob.yml@self
       parameters:
-        BuildConfiguration: ${{ parameters.BuildConfiguration }}
         CodeGenBuildVersion: ${{ parameters.CodeGenBuildVersion }}
         OfficialBuild: ${{ parameters.OfficialBuild }}
 
@@ -32,7 +29,6 @@ stages:
   jobs:
     - template: SdkBuildJob.yml@self
       parameters:
-        BuildConfiguration: ${{ parameters.BuildConfiguration }}
         SdkBuildVersion:  ${{ parameters.SdkBuildVersion }}
         CodeGenBuildVersion: ${{ parameters.CodeGenBuildVersion }}
         OfficialBuild: ${{ parameters.OfficialBuild }}

--- a/AzurePipelineTemplates/jobs/SdkBuildJob.yml
+++ b/AzurePipelineTemplates/jobs/SdkBuildJob.yml
@@ -51,14 +51,14 @@ jobs:
     VeilHostPdbARM64Debug: vbsenclave_sdk_host_ARM64_Debug_pdb=$(Arm64DebugBuildLocation)\veil_host_lib\veil_host_ARM64_Debug_lib.pdb
     
     # veil_cpp_support_lib pack args
-    VeilCppSuportLibX64Release: vbsenclave_sdk_cpp_support_x64_Release_lib=$(x64ReleaseBuildLocation)\veil_cpp_support_x64_Release_lib.lib  
-    VeilCppSuportLibX64Debug: vbsenclave_sdk_cpp_support_x64_Debug_lib=$(x64DebugBuildLocation)\veil_cpp_support_x64_Debug_lib.lib
-    VeilCppSuportLibARM64Release: vbsenclave_sdk_cpp_support_ARM64_Release_lib=$(Arm64ReleaseBuildLocation)\veil_cpp_support_ARM64_Release_lib.lib
-    VeilCppSuportLibARM64Debug: vbsenclave_sdk_cpp_support_ARM64_Debug_lib=$(Arm64DebugBuildLocation)\veil_cpp_support_ARM64_Debug_lib.lib
-    VeilCppSuportPdbX64Release: vbsenclave_sdk_cpp_support_x64_Release_pdb=$(x64ReleaseBuildLocation)\veil_cpp_support_x64_Release_lib.pdb  
-    VeilCppSuportPdbX64Debug: vbsenclave_sdk_cpp_support_x64_Debug_pdb=$(x64DebugBuildLocation)\veil_cpp_support_x64_Debug_lib.pdb
-    VeilCppSuportPdbARM64Release: vbsenclave_sdk_cpp_support_ARM64_Release_pdb=$(Arm64ReleaseBuildLocation)\veil_cpp_support_ARM64_Release_lib.pdb
-    VeilCppSuportPdbARM64Debug: vbsenclave_sdk_cpp_support_ARM64_Debug_pdb=$(Arm64DebugBuildLocation)\veil_cpp_support_ARM64_Debug_lib.pdb
+    VeilCppSupportLibX64Release: vbsenclave_sdk_cpp_support_x64_Release_lib=$(x64ReleaseBuildLocation)\veil_cpp_support_x64_Release_lib.lib  
+    VeilCppSupportLibX64Debug: vbsenclave_sdk_cpp_support_x64_Debug_lib=$(x64DebugBuildLocation)\veil_cpp_support_x64_Debug_lib.lib
+    VeilCppSupportLibARM64Release: vbsenclave_sdk_cpp_support_ARM64_Release_lib=$(Arm64ReleaseBuildLocation)\veil_cpp_support_ARM64_Release_lib.lib
+    VeilCppSupportLibARM64Debug: vbsenclave_sdk_cpp_support_ARM64_Debug_lib=$(Arm64DebugBuildLocation)\veil_cpp_support_ARM64_Debug_lib.lib
+    VeilCppSupportPdbX64Release: vbsenclave_sdk_cpp_support_x64_Release_pdb=$(x64ReleaseBuildLocation)\veil_cpp_support_x64_Release_lib.pdb  
+    VeilCppSupportPdbX64Debug: vbsenclave_sdk_cpp_support_x64_Debug_pdb=$(x64DebugBuildLocation)\veil_cpp_support_x64_Debug_lib.pdb
+    VeilCppSupportPdbARM64Release: vbsenclave_sdk_cpp_support_ARM64_Release_pdb=$(Arm64ReleaseBuildLocation)\veil_cpp_support_ARM64_Release_lib.pdb
+    VeilCppSupportPdbARM64Debug: vbsenclave_sdk_cpp_support_ARM64_Debug_pdb=$(Arm64DebugBuildLocation)\veil_cpp_support_ARM64_Debug_lib.pdb
     
   steps:
    # Download the nupkg file from the codegen job
@@ -175,7 +175,7 @@ jobs:
       displayName: 'Build SDK NuGet package'
       inputs:
         command: 'custom'
-        arguments: 'pack src\VbsEnclaveSDK\src\veil_nuget\Nuget\Microsoft.Windows.VbsEnclave.SDK.nuspec -NonInteractive -OutputDirectory $(BaseBuildDirectory) -Properties target_version=$(SdkNugetPackageVersion);$(VeilEnclaveLibX64Release);$(VeilEnclaveLibX64Debug);$(VeilEnclaveLibARM64Release);$(VeilEnclaveLibARM64Debug);$(VeilHostLibX64Release);$(VeilHostLibX64Debug);$(VeilHostLibARM64Release);$(VeilHostLibARM64Debug);$(VeilCppSuportLibX64Release);$(VeilCppSuportLibX64Debug);$(VeilCppSuportLibARM64Release);$(VeilCppSuportLibARM64Debug);$(VeilEnclavePdbX64Release);$(VeilEnclavePdbX64Debug);$(VeilEnclavePdbARM64Release);$(VeilEnclavePdbARM64Debug);$(VeilHostPdbX64Release);$(VeilHostPdbX64Debug);$(VeilHostPdbARM64Release);$(VeilHostPdbARM64Debug);$(VeilCppSuportPdbX64Release);$(VeilCppSuportPdbX64Debug);$(VeilCppSuportPdbARM64Release);$(VeilCppSuportPdbARM64Debug); -Version $(SdkNugetPackageVersion) -Verbosity Detailed'
+        arguments: 'pack src\VbsEnclaveSDK\src\veil_nuget\Nuget\Microsoft.Windows.VbsEnclave.SDK.nuspec -NonInteractive -OutputDirectory $(BaseBuildDirectory) -Properties target_version=$(SdkNugetPackageVersion);$(VeilEnclaveLibX64Release);$(VeilEnclaveLibX64Debug);$(VeilEnclaveLibARM64Release);$(VeilEnclaveLibARM64Debug);$(VeilHostLibX64Release);$(VeilHostLibX64Debug);$(VeilHostLibARM64Release);$(VeilHostLibARM64Debug);$(VeilCppSupportLibX64Release);$(VeilCppSupportLibX64Debug);$(VeilCppSupportLibARM64Release);$(VeilCppSupportLibARM64Debug);$(VeilEnclavePdbX64Release);$(VeilEnclavePdbX64Debug);$(VeilEnclavePdbARM64Release);$(VeilEnclavePdbARM64Debug);$(VeilHostPdbX64Release);$(VeilHostPdbX64Debug);$(VeilHostPdbARM64Release);$(VeilHostPdbARM64Debug);$(VeilCppSupportPdbX64Release);$(VeilCppSupportPdbX64Debug);$(VeilCppSupportPdbARM64Release);$(VeilCppSupportPdbARM64Debug); -Version $(SdkNugetPackageVersion) -Verbosity Detailed'
 
     # Sign sdk nuget package
     - task: onebranch.pipeline.signing@1

--- a/AzurePipelineTemplates/jobs/SdkBuildJob.yml
+++ b/AzurePipelineTemplates/jobs/SdkBuildJob.yml
@@ -35,20 +35,31 @@ jobs:
     VeilEnclaveLibX64Debug: vbsenclave_sdk_enclave_x64_Debug_lib=$(x64DebugBuildLocation)\veil_enclave_x64_Debug_lib.lib
     VeilEnclaveLibARM64Release: vbsenclave_sdk_enclave_ARM64_Release_lib=$(Arm64ReleaseBuildLocation)\veil_enclave_ARM64_Release_lib
     VeilEnclaveLibARM64Debug: vbsenclave_sdk_enclave_ARM64_Debug_lib=$(Arm64DebugBuildLocation)\veil_enclave_ARM64_Debug_lib
-
+    VeilEnclavePdbX64Release: vbsenclave_sdk_enclave_x64_Release_pdb=$(x64ReleaseBuildLocation)\veil_enclave_x64_Release_lib.pdb  
+    VeilEnclavePdbX64Debug: vbsenclave_sdk_enclave_x64_Debug_pdb=$(x64DebugBuildLocation)\veil_enclave_x64_Debug_lib.pdb
+    VeilEnclavePdbARM64Release: vbsenclave_sdk_enclave_ARM64_Release_pdb=$(Arm64ReleaseBuildLocation)\veil_enclave_ARM64_Release_lib.pdb
+    VeilEnclavePdbARM64Debug: vbsenclave_sdk_enclave_ARM64_Debug_pdb=$(Arm64DebugBuildLocation)\veil_enclave_ARM64_Debug_lib.pdb
+    
     # veil_host_lib pack args
     VeilHostLibX64Release: vbsenclave_sdk_host_x64_Release_lib=$(x64ReleaseBuildLocation)\veil_host_lib\veil_host_x64_Release_lib.lib  
     VeilHostLibX64Debug: vbsenclave_sdk_host_x64_Debug_lib=$(x64DebugBuildLocation)\veil_host_lib\veil_host_x64_Debug_lib.lib
-    VeilHostLibARM64Release: vbsenclave_sdk_host_ARM64_Release_lib=$(Arm64ReleaseBuildLocation)\veil_host_lib\veil_host_ARM64_Release_lib
-    VeilHostLibARM64Debug: vbsenclave_sdk_host_ARM64_Debug_lib=$(Arm64DebugBuildLocation)\veil_host_lib\veil_host_ARM64_Debug_lib
-
+    VeilHostLibARM64Release: vbsenclave_sdk_host_ARM64_Release_lib=$(Arm64ReleaseBuildLocation)\veil_host_lib\veil_host_ARM64_Release_lib.lib
+    VeilHostLibARM64Debug: vbsenclave_sdk_host_ARM64_Debug_lib=$(Arm64DebugBuildLocation)\veil_host_lib\veil_host_ARM64_Debug_lib.lib
+    VeilHostPdbX64Release: vbsenclave_sdk_host_x64_Release_pdb=$(x64ReleaseBuildLocation)\veil_host_lib\veil_host_x64_Release_lib.pdb  
+    VeilHostPdbX64Debug: vbsenclave_sdk_host_x64_Debug_pdb=$(x64DebugBuildLocation)\veil_host_lib\veil_host_x64_Debug_lib.pdb
+    VeilHostPdbARM64Release: vbsenclave_sdk_host_ARM64_Release_pdb=$(Arm64ReleaseBuildLocation)\veil_host_lib\veil_host_ARM64_Release_lib.pdb
+    VeilHostPdbARM64Debug: vbsenclave_sdk_host_ARM64_Debug_pdb=$(Arm64DebugBuildLocation)\veil_host_lib\veil_host_ARM64_Debug_lib.pdb
+    
     # veil_cpp_support_lib pack args
     VeilCppSuportLibX64Release: vbsenclave_sdk_cpp_support_x64_Release_lib=$(x64ReleaseBuildLocation)\veil_cpp_support_x64_Release_lib.lib  
     VeilCppSuportLibX64Debug: vbsenclave_sdk_cpp_support_x64_Debug_lib=$(x64DebugBuildLocation)\veil_cpp_support_x64_Debug_lib.lib
-    VeilCppSuportLibARM64Release: vbsenclave_sdk_cpp_support_ARM64_Release_lib=$(Arm64ReleaseBuildLocation)\veil_cpp_support_ARM64_Release_lib
-    VeilCppSuportLibARM64Debug: vbsenclave_sdk_cpp_support_ARM64_Debug_lib=$(Arm64DebugBuildLocation)\veil_cpp_support_ARM64_Debug_lib
-
-
+    VeilCppSuportLibARM64Release: vbsenclave_sdk_cpp_support_ARM64_Release_lib=$(Arm64ReleaseBuildLocation)\veil_cpp_support_ARM64_Release_lib.lib
+    VeilCppSuportLibARM64Debug: vbsenclave_sdk_cpp_support_ARM64_Debug_lib=$(Arm64DebugBuildLocation)\veil_cpp_support_ARM64_Debug_lib.lib
+    VeilCppSuportPdbX64Release: vbsenclave_sdk_cpp_support_x64_Release_pdb=$(x64ReleaseBuildLocation)\veil_cpp_support_x64_Release_lib.pdb  
+    VeilCppSuportPdbX64Debug: vbsenclave_sdk_cpp_support_x64_Debug_pdb=$(x64DebugBuildLocation)\veil_cpp_support_x64_Debug_lib.pdb
+    VeilCppSuportPdbARM64Release: vbsenclave_sdk_cpp_support_ARM64_Release_pdb=$(Arm64ReleaseBuildLocation)\veil_cpp_support_ARM64_Release_lib.pdb
+    VeilCppSuportPdbARM64Debug: vbsenclave_sdk_cpp_support_ARM64_Debug_pdb=$(Arm64DebugBuildLocation)\veil_cpp_support_ARM64_Debug_lib.pdb
+    
   steps:
    # Download the nupkg file from the codegen job
     - task: DownloadPipelineArtifact@2
@@ -164,7 +175,7 @@ jobs:
       displayName: 'Build SDK NuGet package'
       inputs:
         command: 'custom'
-        arguments: 'pack src\VbsEnclaveSDK\src\veil_nuget\Nuget\Microsoft.Windows.VbsEnclave.SDK.nuspec -NonInteractive -OutputDirectory $(BaseBuildDirectory) -Properties target_version=$(SdkNugetPackageVersion);$(VeilEnclaveLibX64Release);$(VeilEnclaveLibX64Debug);$(VeilEnclaveLibARM64Release);$(VeilEnclaveLibARM64Debug);$(VeilHostLibX64Release);$(VeilHostLibX64Debug);$(VeilHostLibARM64Release);$(VeilHostLibARM64Debug);$(VeilCppSuportLibX64Release);$(VeilCppSuportLibX64Debug);$(VeilCppSuportLibARM64Release);$(VeilCppSuportLibARM64Debug); -Version $(SdkNugetPackageVersion) -Verbosity Detailed'
+        arguments: 'pack src\VbsEnclaveSDK\src\veil_nuget\Nuget\Microsoft.Windows.VbsEnclave.SDK.nuspec -NonInteractive -OutputDirectory $(BaseBuildDirectory) -Properties target_version=$(SdkNugetPackageVersion);$(VeilEnclaveLibX64Release);$(VeilEnclaveLibX64Debug);$(VeilEnclaveLibARM64Release);$(VeilEnclaveLibARM64Debug);$(VeilHostLibX64Release);$(VeilHostLibX64Debug);$(VeilHostLibARM64Release);$(VeilHostLibARM64Debug);$(VeilCppSuportLibX64Release);$(VeilCppSuportLibX64Debug);$(VeilCppSuportLibARM64Release);$(VeilCppSuportLibARM64Debug);$(VeilEnclavePdbX64Release);$(VeilEnclavePdbX64Debug);$(VeilEnclavePdbARM64Release);$(VeilEnclavePdbARM64Debug);$(VeilHostPdbX64Release);$(VeilHostPdbX64Debug);$(VeilHostPdbARM64Release);$(VeilHostPdbARM64Debug);$(VeilCppSuportPdbX64Release);$(VeilCppSuportPdbX64Debug);$(VeilCppSuportPdbARM64Release);$(VeilCppSuportPdbARM64Debug); -Version $(SdkNugetPackageVersion) -Verbosity Detailed'
 
     # Sign sdk nuget package
     - task: onebranch.pipeline.signing@1

--- a/AzurePipelineTemplates/jobs/SdkBuildJob.yml
+++ b/AzurePipelineTemplates/jobs/SdkBuildJob.yml
@@ -1,7 +1,5 @@
 ﻿# build file for the veil soliution using the x64 and arm64 platforms
 parameters:
-  - name: BuildConfiguration
-    type: string
   - name: CodeGenBuildVersion
     type: string
   - name: SdkBuildVersion
@@ -24,10 +22,32 @@ jobs:
     NewCodeGenVersion: ${{ parameters.CodeGenBuildVersion }}
     ob_outputDirectory: '$(Build.SourcesDirectory)\signed_nuget'   
     ob_artifactBaseName: signed_sdk_nuget_package
-    BuildConfiguration: ${{ parameters.BuildConfiguration }}
     SdkNugetPackageVersion: ${{ parameters.SdkBuildVersion }}
     BaseBuildDirectory: $(Build.SourcesDirectory)\_build
     SdkBuildDirectory: $(Build.SourcesDirectory)\src\VbsEnclaveSDK\_build
+    x64ReleaseBuildLocation: $(SdkBuildDirectory)\x64\Release
+    x64DebugBuildLocation: $(SdkBuildDirectory)\x64\Debug
+    Arm64ReleaseBuildLocation: $(SdkBuildDirectory)\ARM64\Release
+    Arm64DebugBuildLocation: $(SdkBuildDirectory)\ARM64\Debug
+
+    # veil_enclave_lib pack args
+    VeilEnclaveLibX64Release: vbsenclave_sdk_enclave_x64_Release_lib=$(x64ReleaseBuildLocation)\veil_enclave_x64_Release_lib.lib  
+    VeilEnclaveLibX64Debug: vbsenclave_sdk_enclave_x64_Debug_lib=$(x64DebugBuildLocation)\veil_enclave_x64_Debug_lib.lib
+    VeilEnclaveLibARM64Release: vbsenclave_sdk_enclave_ARM64_Release_lib=$(Arm64ReleaseBuildLocation)\veil_enclave_ARM64_Release_lib
+    VeilEnclaveLibARM64Debug: vbsenclave_sdk_enclave_ARM64_Debug_lib=$(Arm64DebugBuildLocation)\veil_enclave_ARM64_Debug_lib
+
+    # veil_host_lib pack args
+    VeilHostLibX64Release: vbsenclave_sdk_host_x64_Release_lib=$(x64ReleaseBuildLocation)\veil_host_lib\veil_host_x64_Release_lib.lib  
+    VeilHostLibX64Debug: vbsenclave_sdk_host_x64_Debug_lib=$(x64DebugBuildLocation)\veil_host_lib\veil_host_x64_Debug_lib.lib
+    VeilHostLibARM64Release: vbsenclave_sdk_host_ARM64_Release_lib=$(Arm64ReleaseBuildLocation)\veil_host_lib\veil_host_ARM64_Release_lib
+    VeilHostLibARM64Debug: vbsenclave_sdk_host_ARM64_Debug_lib=$(Arm64DebugBuildLocation)\veil_host_lib\veil_host_ARM64_Debug_lib
+
+    # veil_cpp_support_lib pack args
+    VeilCppSuportLibX64Release: vbsenclave_sdk_cpp_support_x64_Release_lib=$(x64ReleaseBuildLocation)\veil_cpp_support_x64_Release_lib.lib  
+    VeilCppSuportLibX64Debug: vbsenclave_sdk_cpp_support_x64_Debug_lib=$(x64DebugBuildLocation)\veil_cpp_support_x64_Debug_lib.lib
+    VeilCppSuportLibARM64Release: vbsenclave_sdk_cpp_support_ARM64_Release_lib=$(Arm64ReleaseBuildLocation)\veil_cpp_support_ARM64_Release_lib
+    VeilCppSuportLibARM64Debug: vbsenclave_sdk_cpp_support_ARM64_Debug_lib=$(Arm64DebugBuildLocation)\veil_cpp_support_ARM64_Debug_lib
+
 
   steps:
    # Download the nupkg file from the codegen job
@@ -106,18 +126,32 @@ jobs:
         nugetConfigPath: NuGet.config
 
     - task: VSBuild@1
-      displayName: 'Build Veil Solution x64'
+      displayName: 'Build Veil Solution x64 release'
       inputs:
         solution: $(SdkSolution)
         platform:  'x64'
-        configuration: $(BuildConfiguration)
+        configuration: 'Release'
 
     - task: VSBuild@1
-      displayName: 'Build Veil Solution  arm64'
+      displayName: 'Build Veil Solution  arm64 release'
       inputs:
         solution: $(SdkSolution)
         platform:  'arm64'
-        configuration: $(BuildConfiguration)
+        configuration: 'Release'
+
+    - task: VSBuild@1
+      displayName: 'Build Veil Solution x64 debug'
+      inputs:
+        solution: $(SdkSolution)
+        platform:  'x64'
+        configuration: 'Debug'
+
+    - task: VSBuild@1
+      displayName: 'Build Veil Solution  arm64 debug'
+      inputs:
+        solution: $(SdkSolution)
+        platform:  'arm64'
+        configuration: 'Debug'
 
     - task: NuGetToolInstaller@1
       displayName: Use NuGet 6.0.2
@@ -130,7 +164,7 @@ jobs:
       displayName: 'Build SDK NuGet package'
       inputs:
         command: 'custom'
-        arguments: 'pack src\VbsEnclaveSDK\src\veil_nuget\Nuget\Microsoft.Windows.VbsEnclave.SDK.nuspec -NonInteractive -OutputDirectory $(BaseBuildDirectory) -Properties target_version=$(SdkNugetPackageVersion);vbsenclave_sdk_enclave_x64_lib=$(SdkBuildDirectory)\x64\$(BuildConfiguration)\veil_enclave_lib.lib;vbsenclave_sdk_enclave_arm64_lib=$(SdkBuildDirectory)\arm64\$(BuildConfiguration)\veil_enclave_lib.lib;vbsenclave_sdk_host_x64_lib=$(SdkBuildDirectory)\x64\$(BuildConfiguration)\veil_host_lib\veil_host_lib.lib;vbsenclave_sdk_host_arm64_lib=$(SdkBuildDirectory)\arm64\$(BuildConfiguration)\veil_host_lib\veil_host_lib.lib;vbsenclave_sdk_cpp_support_x64_lib=$(SdkBuildDirectory)\x64\$(BuildConfiguration)\veil_enclave_cpp_support_lib.lib;vbsenclave_sdk_cpp_support_arm64_lib=$(SdkBuildDirectory)\arm64\$(BuildConfiguration)\veil_enclave_cpp_support_lib.lib; -Version $(SdkNugetPackageVersion) -Verbosity Detailed'
+        arguments: 'pack src\VbsEnclaveSDK\src\veil_nuget\Nuget\Microsoft.Windows.VbsEnclave.SDK.nuspec -NonInteractive -OutputDirectory $(BaseBuildDirectory) -Properties target_version=$(SdkNugetPackageVersion);$(VeilEnclaveLibX64Release);$(VeilEnclaveLibX64Debug);$(VeilEnclaveLibARM64Release);$(VeilEnclaveLibARM64Debug);$(VeilHostLibX64Release);$(VeilHostLibX64Debug);$(VeilHostLibARM64Release);$(VeilHostLibARM64Debug);$(VeilCppSuportLibX64Release);$(VeilCppSuportLibX64Debug);$(VeilCppSuportLibARM64Release);$(VeilCppSuportLibARM64Debug); -Version $(SdkNugetPackageVersion) -Verbosity Detailed'
 
     # Sign sdk nuget package
     - task: onebranch.pipeline.signing@1

--- a/AzurePipelineTemplates/variables/version.yml
+++ b/AzurePipelineTemplates/variables/version.yml
@@ -10,7 +10,7 @@ variables:
 - name: CodeGenMinorVersion
   value: "0"
 - name: CodeGenPatchVersion
-  value: "1"
+  value: "2"
 
 
 # SDK versioning info
@@ -19,7 +19,7 @@ variables:
 - name: SdkMinorVersion
   value: "0"
 - name: SdkPatchVersion
-  value: "1"
+  value: "2"
 
 
 # Conditionally set values if branch name starts with 'prerelease'

--- a/Common/veil_enclave_cpp_support_lib/veil_enclave_cpp_support_lib.vcxproj
+++ b/Common/veil_enclave_cpp_support_lib/veil_enclave_cpp_support_lib.vcxproj
@@ -36,7 +36,7 @@
     <UES_ComponentName>veil_enclave_cpp_support_lib</UES_ComponentName>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetName>veil_enclave_cpp_support_lib</TargetName>
+    <TargetName>veil_enclave_cpp_support_$(Platform)_$(Configuration)_lib</TargetName>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup>

--- a/buildScripts/build.ps1
+++ b/buildScripts/build.ps1
@@ -1,12 +1,12 @@
 [CmdletBinding()]
 Param(
-    [ValidateSet('x64', 'arm64')]
+    [ValidateSet('all', 'x64', 'ARM64')]
     [System.String]
-    $Platform = "x64",
+    $Platform = "all",
     
-    [ValidateSet('debug', 'release')]
+    [ValidateSet('all', 'Debug', 'Release')]
     [System.String]
-    $Configuration = "debug",
+    $Configuration = "all",
 
     [ValidateSet('all', 'CodeGenOnly')]
     [System.String]
@@ -35,10 +35,12 @@ Options:
   -Platform <platform>
       Only build the selected platform(s)
       Example: -Platform x64
+      Example: -Platform all
 
   -Configuration <configuration>
       Only build the selected configuration(s)
       Example: -Configuration release
+      Example: -Configuration all
 
   -Help
       Display this usage message.
@@ -50,11 +52,24 @@ Options:
 $ErrorActionPreference = "Stop"
 $BuildRootDirectory = (Split-Path $MyInvocation.MyCommand.Path)
 $BaseRepositoryDirectory = Split-Path $BuildRootDirectory
+$BuildPlatform = @($Platform)
+$BuildConfiguration = @($Configuration)
+
+if ($Platform -eq "all")
+{
+    $BuildPlatform = @("x64", "ARM64")
+}
+
+if ($Configuration -eq "all")
+{
+    $BuildConfiguration = @("Release", "Debug")
+}
 
 # Use the triple zeros as the version number for local builds.
 $BuildTargetVersion = [System.Version]::new(0, 0, 0)
 $msbuildPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -prerelease -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe
 
+   
 Try 
 {
     $solutionName = "VbsEnclaveTooling"
@@ -65,23 +80,41 @@ Try
     Write-Host "Running nuget restore for $solutionName"
     & $nugetPath restore "$BaseRepositoryDirectory\$solutionName.sln"
 
-    # Build
-    
-    Write-Host "Building $solutionName for EnvPlatform: $BuildPlatform Platform: $platform Configuration: $configuration"
-    $msbuildArgs = 
-    @(
-        ("$BaseRepositoryDirectory\$solutionName.sln"),
-        ("/p:Platform=$Platform"),
-        ("/p:Configuration=$Configuration"),
-        ("/restore"),
-        ("/binaryLogger:$BaseRepositoryDirectory\_build\$platform\$configuration\$solutionName.$platform.$configuration.binlog")
-    )
+    $edlcodegen_exe_path = ""
 
-    & $msbuildPath $msbuildArgs
-    if ($LASTEXITCODE -ne 0)
+    # Build
+    foreach ($platform in $BuildPlatform)
     {
-        Write-Error "MSBuild failed with exit code $LASTEXITCODE"
-        exit $LASTEXITCODE
+        foreach ($configuration in $Build_Configuration)
+        {
+            Write-Host "Building $solutionName for EnvPlatform: $BuildPlatform Platform: $platform Configuration: $configuration"
+            $msbuildArgs = 
+            @(
+                ("$BaseRepositoryDirectory\$solutionName.sln"),
+                ("/p:Platform=$Platform"),
+                ("/p:Configuration=$Configuration"),
+                ("/restore"),
+                ("/binaryLogger:$BaseRepositoryDirectory\_build\$platform\$configuration\$solutionName.$platform.$configuration.binlog")
+            )
+
+            & $msbuildPath $msbuildArgs
+            if ($LASTEXITCODE -ne 0)
+            {
+                Write-Error "MSBuild failed with exit code $LASTEXITCODE"
+                exit $LASTEXITCODE
+            }
+
+            $cppSupportLibPath = "$BaseRepositoryDirectory\_build\$platform\$configuration\veil_enclave_cpp_support_${platform}_${configuration}_lib.lib"
+            $nugetPackProperties += "vbsenclave_codegen_cpp_support_${platform}_${configuration}_lib=$cppSupportLibPath;"
+
+            # only need the exe path once. If the user uses the -all flag for the configuration, we use the release version. Otherwise
+            # we use the specified user provided configuration. e.g debug or release.
+            if ($edlcodegen_exe_path -eq "")
+            {
+                $edlcodegen_exe_path = "vbsenclave_codegen_x64_exe=$BaseRepositoryDirectory\_build\x64\$configuration\edlcodegen.exe;"
+                $nugetPackProperties += $edlcodegen_exe_path
+            }
+        }
     }
 
     # Now create the nuget package 
@@ -89,9 +122,6 @@ Try
     $nugetPackProperties = "target_version=$BuildTargetVersion;"
     $nugetPackProperties += "vcpkg_sources=$BaseRepositoryDirectory\src\ToolingSharedLibrary\vcpkg_installed\x64-windows-static\x64-windows-static;";
     $nugetPackProperties += "vcpkg_tools=$BaseRepositoryDirectory\src\ToolingSharedLibrary\vcpkg_installed\x64-windows-static\x64-windows\tools;";
-    $nugetPackProperties += "vbsenclave_codegen_x64_exe=$BaseRepositoryDirectory\_build\x64\$configuration\edlcodegen.exe;"
-    $cppSupportLibPath = "$BaseRepositoryDirectory\_build\$platform\$configuration\veil_enclave_cpp_support_lib.lib"
-    $nugetPackProperties += "vbsenclave_codegen_cpp_support_$platform"+"_lib=$cppSupportLibPath;"
           
     # Pack nuget
     $packageNugetScriptPath  = "$BuildRootDirectory\PackageNuget.ps1"
@@ -105,7 +135,7 @@ Catch
     Write-Host ($formatString -f $fields) -ForegroundColor RED
     throw
 }
-
+}
 # Now that we've finished building the codegen project and nuget package, build the sdk project and its nuget package.
 if ($NugetPackagesToOutput -eq "all")
 {

--- a/src/ToolingNuget/Nuget/Microsoft.Windows.VbsEnclave.CodeGenerator.nuspec
+++ b/src/ToolingNuget/Nuget/Microsoft.Windows.VbsEnclave.CodeGenerator.nuspec
@@ -27,8 +27,12 @@
     <file src="..\..\ToolingNuget\Nuget\Microsoft.Windows.VbsEnclave.CodeGenerator.props" target="build\native"/>
     <file src="..\..\ToolingNuget\Nuget\Microsoft.Windows.VbsEnclave.CodeGenerator.targets" target="build\native"/>
     <file src="..\..\ToolingSharedLibrary\Includes\VbsEnclaveABI\**" target="src\VbsEnclaveABI\" />
-    <file src="$vbsenclave_codegen_cpp_support_x64_lib$" target="lib\native\x64"/>
-    <file src="$vbsenclave_codegen_cpp_support_arm64_lib$" target="lib\native\arm64"/>
+      
+    <file src="$vbsenclave_codegen_cpp_support_x64_Release_lib$" target="lib\native\x64"/>
+    <file src="$vbsenclave_codegen_cpp_support_ARM64_Release_lib$" target="lib\native\arm64"/>
+    <file src="$vbsenclave_codegen_cpp_support_x64_Debug_lib$" target="lib\native\x64"/>
+    <file src="$vbsenclave_codegen_cpp_support_ARM64_Debug_lib$" target="lib\native\arm64"/>
+      
     <file src="..\..\..\Common\veil_enclave_wil_inc\**" target="src\" />
     <file src="..\..\..\README.md"/>
     <file src="NOTICE.md"/>

--- a/src/ToolingNuget/Nuget/Microsoft.Windows.VbsEnclave.CodeGenerator.nuspec
+++ b/src/ToolingNuget/Nuget/Microsoft.Windows.VbsEnclave.CodeGenerator.nuspec
@@ -27,11 +27,16 @@
     <file src="..\..\ToolingNuget\Nuget\Microsoft.Windows.VbsEnclave.CodeGenerator.props" target="build\native"/>
     <file src="..\..\ToolingNuget\Nuget\Microsoft.Windows.VbsEnclave.CodeGenerator.targets" target="build\native"/>
     <file src="..\..\ToolingSharedLibrary\Includes\VbsEnclaveABI\**" target="src\VbsEnclaveABI\" />
-      
+
+    <!-- veil C++ support static lib -->
     <file src="$vbsenclave_codegen_cpp_support_x64_Release_lib$" target="lib\native\x64"/>
     <file src="$vbsenclave_codegen_cpp_support_ARM64_Release_lib$" target="lib\native\arm64"/>
     <file src="$vbsenclave_codegen_cpp_support_x64_Debug_lib$" target="lib\native\x64"/>
     <file src="$vbsenclave_codegen_cpp_support_ARM64_Debug_lib$" target="lib\native\arm64"/>
+    <file src="$vbsenclave_codegen_cpp_support_x64_Release_pdb$" target="lib\native\x64"/>
+    <file src="$vbsenclave_codegen_cpp_support_ARM64_Release_pdb$" target="lib\native\arm64"/>
+    <file src="$vbsenclave_codegen_cpp_support_x64_Debug_pdb$" target="lib\native\x64"/>
+    <file src="$vbsenclave_codegen_cpp_support_ARM64_Debug_pdb$" target="lib\native\arm64"/>
       
     <file src="..\..\..\Common\veil_enclave_wil_inc\**" target="src\" />
     <file src="..\..\..\README.md"/>

--- a/src/ToolingNuget/Nuget/Microsoft.Windows.VbsEnclave.CodeGenerator.targets
+++ b/src/ToolingNuget/Nuget/Microsoft.Windows.VbsEnclave.CodeGenerator.targets
@@ -10,7 +10,7 @@
         <VbsEnclaveExeFilePath>$(VbsEnclaveCodegenPackageDir)bin\edlcodegen.exe</VbsEnclaveExeFilePath>
         <VbsEnclavePackageEnclaveAbiPath>$(VbsEnclaveCodegenPackageDir)src\VbsEnclaveABI</VbsEnclavePackageEnclaveAbiPath>
         <VbsEnclaveDeveloperEdlFileName>$([System.IO.Path]::GetFileName('$(VbsEnclaveEdlPath)'))</VbsEnclaveDeveloperEdlFileName>
-        <VbsEnclaveCodeGenAbiCppSupportLib>$(VbsEnclaveCodegenPackageDir)lib\native\$(Platform)\veil_enclave_cpp_support_lib.lib</VbsEnclaveCodeGenAbiCppSupportLib>
+        <VbsEnclaveCodeGenAbiCppSupportLib>$(VbsEnclaveCodegenPackageDir)lib\native\$(Platform)\veil_enclave_cpp_support_$(Platform)_$(Configuration)_lib.lib</VbsEnclaveCodeGenAbiCppSupportLib>
         <VbsEnclaveGeneratedFilesDir>$(ProjectDir)Generated Files</VbsEnclaveGeneratedFilesDir>
         <VcpkgSupportDir>$(VbsEnclaveCodegenPackageDir)vcpkg</VcpkgSupportDir>
         <FlatbuffersCompiler>$(VcpkgSupportDir)\tools\flatbuffers\flatc.exe</FlatbuffersCompiler>

--- a/src/ToolingNuget/Nuget/VisualStudioUiBuild.targets
+++ b/src/ToolingNuget/Nuget/VisualStudioUiBuild.targets
@@ -11,9 +11,10 @@
             nuget package to contain both arm64 and x64 and debug and release libraries use the build.ps1 script in <repo-root>\buildScripts
         -->
         <VbsEnclaveCodeGenNugetPackCppSupportPath>$(OutDir)veil_enclave_cpp_support_$(Platform)_$(Configuration)_lib.lib</VbsEnclaveCodeGenNugetPackCppSupportPath>
+        <VbsEnclaveCodeGenNugetPackCppSupportPdbPath>$(OutDir)veil_enclave_cpp_support_$(Platform)_$(Configuration)_lib.pdb</VbsEnclaveCodeGenNugetPackCppSupportPdbPath>
         <VcpkgSupportPath>$(SolutionDir)src\ToolingSharedLibrary\vcpkg_installed\x64-windows-static\x64-windows-static</VcpkgSupportPath>
         <VcpkgToolsPath>$(SolutionDir)src\ToolingSharedLibrary\vcpkg_installed\x64-windows-static\x64-windows\tools</VcpkgToolsPath>
-        <VbsEnclaveNugetPackProperties>target_version=$(VbsEnclaveCodeGenNugetPackVersionNumber);vbsenclave_codegen_x64_exe=$(VbsEnclaveCodegenNugetPackExePath);vcpkg_sources=$(VcpkgSupportPath);vcpkg_tools=$(VcpkgToolsPath);vbsenclave_codegen_cpp_support_$(Platform)_$(configuration)_lib=$(VbsEnclaveCodeGenNugetPackCppSupportPath);</VbsEnclaveNugetPackProperties>
+        <VbsEnclaveNugetPackProperties>target_version=$(VbsEnclaveCodeGenNugetPackVersionNumber);vbsenclave_codegen_x64_exe=$(VbsEnclaveCodegenNugetPackExePath);vcpkg_sources=$(VcpkgSupportPath);vcpkg_tools=$(VcpkgToolsPath);vbsenclave_codegen_cpp_support_$(Platform)_$(configuration)_lib=$(VbsEnclaveCodeGenNugetPackCppSupportPath);vbsenclave_codegen_cpp_support_$(Platform)_$(configuration)_pdb=$(VbsEnclaveCodeGenNugetPackCppSupportPdbPath);</VbsEnclaveNugetPackProperties>
         <VbsEnclaveNugetPackOutputDirectory>$(SolutionDir)_build</VbsEnclaveNugetPackOutputDirectory>
         <VbsEnclaveNugetPackScriptFile>$(SolutionDir)buildScripts\PackageNuget.ps1</VbsEnclaveNugetPackScriptFile>
     </PropertyGroup>

--- a/src/ToolingNuget/Nuget/VisualStudioUiBuild.targets
+++ b/src/ToolingNuget/Nuget/VisualStudioUiBuild.targets
@@ -5,10 +5,15 @@
 
         <!-- Property value should match the "ToolingExecutable" projects 'target name' property  -->
         <VbsEnclaveCodegenNugetPackExePath>$(SolutionDir)_build\x64\$(Configuration)\edlcodegen.exe</VbsEnclaveCodegenNugetPackExePath>
-        <VbsEnclaveCodeGenNugetPackCppSupportPath>$(OutDir)veil_enclave_cpp_support_lib.lib</VbsEnclaveCodeGenNugetPackCppSupportPath>
+        
+        <!-- 
+            Note: Currently we only support building one platform and one configuration at a time when using the Visual Studio UI. If you need the CodeGenerator
+            nuget package to contain both arm64 and x64 and debug and release libraries use the build.ps1 script in <repo-root>\buildScripts
+        -->
+        <VbsEnclaveCodeGenNugetPackCppSupportPath>$(OutDir)veil_enclave_cpp_support_$(Platform)_$(Configuration)_lib.lib</VbsEnclaveCodeGenNugetPackCppSupportPath>
         <VcpkgSupportPath>$(SolutionDir)src\ToolingSharedLibrary\vcpkg_installed\x64-windows-static\x64-windows-static</VcpkgSupportPath>
         <VcpkgToolsPath>$(SolutionDir)src\ToolingSharedLibrary\vcpkg_installed\x64-windows-static\x64-windows\tools</VcpkgToolsPath>
-        <VbsEnclaveNugetPackProperties>target_version=$(VbsEnclaveCodeGenNugetPackVersionNumber);vbsenclave_codegen_x64_exe=$(VbsEnclaveCodegenNugetPackExePath);vcpkg_sources=$(VcpkgSupportPath);vcpkg_tools=$(VcpkgToolsPath);vbsenclave_codegen_cpp_support_$(Platform)_lib=$(VbsEnclaveCodeGenNugetPackCppSupportPath);</VbsEnclaveNugetPackProperties>
+        <VbsEnclaveNugetPackProperties>target_version=$(VbsEnclaveCodeGenNugetPackVersionNumber);vbsenclave_codegen_x64_exe=$(VbsEnclaveCodegenNugetPackExePath);vcpkg_sources=$(VcpkgSupportPath);vcpkg_tools=$(VcpkgToolsPath);vbsenclave_codegen_cpp_support_$(Platform)_$(configuration)_lib=$(VbsEnclaveCodeGenNugetPackCppSupportPath);</VbsEnclaveNugetPackProperties>
         <VbsEnclaveNugetPackOutputDirectory>$(SolutionDir)_build</VbsEnclaveNugetPackOutputDirectory>
         <VbsEnclaveNugetPackScriptFile>$(SolutionDir)buildScripts\PackageNuget.ps1</VbsEnclaveNugetPackScriptFile>
     </PropertyGroup>

--- a/src/VbsEnclaveSDK/src/veil_enclave_lib/veil_enclave_lib.vcxproj
+++ b/src/VbsEnclaveSDK/src/veil_enclave_lib/veil_enclave_lib.vcxproj
@@ -28,7 +28,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{323433E4-11D6-4B5B-93E4-04504E2EF0E1}</ProjectGuid>
     <RootNamespace>veil_enclave_lib</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <PlatformToolset>v143</PlatformToolset>
     <ProjectName>veil_enclave_lib</ProjectName>
@@ -41,7 +41,7 @@
   </ImportGroup>
   <ImportGroup Label="ExtensionSettings" />
   <PropertyGroup>
-    <TargetName>veil_enclave_lib</TargetName>
+    <TargetName>veil_enclave_$(Platform)_$(Configuration)_lib</TargetName>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/VbsEnclaveSDK/src/veil_host_lib/veil_host_lib.vcxproj
+++ b/src/VbsEnclaveSDK/src/veil_host_lib/veil_host_lib.vcxproj
@@ -39,6 +39,18 @@
   <PropertyGroup>
     <UseFullStaticPrivate>true</UseFullStaticPrivate>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <TargetName>veil_host_$(Platform)_$(Configuration)_lib</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <TargetName>veil_host_$(Platform)_$(Configuration)_lib</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <TargetName>veil_host_$(Platform)_$(Configuration)_lib</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <TargetName>veil_host_$(Platform)_$(Configuration)_lib</TargetName>
+  </PropertyGroup>
   <PropertyGroup Label="UES.Globals">
     <UES_ProjectType />
   </PropertyGroup>
@@ -122,7 +134,7 @@
     <ClCompile Include="utils.vtl0.cpp" />
     <ClCompile Include="vtl0_functions.vtl0.cpp" />
   </ItemGroup>
-    <ImportGroup Label="ExtensionTargets">
+  <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.240803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.240803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.0.0\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.0.0\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.targets')" />
   </ImportGroup>

--- a/src/VbsEnclaveSDK/src/veil_nuget/Nuget/Microsoft.Windows.VbsEnclave.SDK.nuspec
+++ b/src/VbsEnclaveSDK/src/veil_nuget/Nuget/Microsoft.Windows.VbsEnclave.SDK.nuspec
@@ -31,12 +31,22 @@
     <file src="..\..\veil_host_lib\**\*.h" exclude="..\..\veil_enclave_lib\Generated Files\**\*" target="src\veil\host" />
     <file src="..\..\veil_any_inc\**" target="src\veil\veil_any_inc" />
     <file src="..\..\..\..\..\Common\veil_enclave_wil_inc\**" target="src\" />
-    <file src="$vbsenclave_sdk_enclave_x64_lib$" target="lib\native\x64"/>
-    <file src="$vbsenclave_sdk_enclave_arm64_lib$" target="lib\native\arm64"/>
-    <file src="$vbsenclave_sdk_host_x64_lib$" target="lib\native\x64"/>
-    <file src="$vbsenclave_sdk_host_arm64_lib$" target="lib\native\arm64"/>
-    <file src="$vbsenclave_sdk_cpp_support_x64_lib$" target="lib\native\x64"/>
-    <file src="$vbsenclave_sdk_cpp_support_arm64_lib$" target="lib\native\arm64"/>
+      
+    <file src="$vbsenclave_sdk_enclave_x64_Release_lib$" target="lib\native\x64"/>
+    <file src="$vbsenclave_sdk_enclave_ARM64_Release_lib$" target="lib\native\arm64"/>
+    <file src="$vbsenclave_sdk_enclave_x64_Debug_lib$" target="lib\native\x64"/>
+    <file src="$vbsenclave_sdk_enclave_ARM64_Debug_lib$" target="lib\native\arm64"/>
+      
+    <file src="$vbsenclave_sdk_host_x64_Release_lib$" target="lib\native\x64"/>
+    <file src="$vbsenclave_sdk_host_ARM64_Release_lib$" target="lib\native\arm64"/>
+    <file src="$vbsenclave_sdk_host_x64_Debug_lib$" target="lib\native\x64"/>
+    <file src="$vbsenclave_sdk_host_ARM64_Debug_lib$" target="lib\native\arm64"/>
+      
+    <file src="$vbsenclave_sdk_cpp_support_x64_Release_lib$" target="lib\native\x64"/>
+    <file src="$vbsenclave_sdk_cpp_support_ARM64_Release_lib$" target="lib\native\arm64"/>
+    <file src="$vbsenclave_sdk_cpp_support_x64_Debug_lib$" target="lib\native\x64"/>
+    <file src="$vbsenclave_sdk_cpp_support_ARM64_Debug_lib$" target="lib\native\arm64"/>
+      
     <file src="..\..\..\README.md"/>
   </files>
 </package>

--- a/src/VbsEnclaveSDK/src/veil_nuget/Nuget/Microsoft.Windows.VbsEnclave.SDK.nuspec
+++ b/src/VbsEnclaveSDK/src/veil_nuget/Nuget/Microsoft.Windows.VbsEnclave.SDK.nuspec
@@ -31,21 +31,36 @@
     <file src="..\..\veil_host_lib\**\*.h" exclude="..\..\veil_enclave_lib\Generated Files\**\*" target="src\veil\host" />
     <file src="..\..\veil_any_inc\**" target="src\veil\veil_any_inc" />
     <file src="..\..\..\..\..\Common\veil_enclave_wil_inc\**" target="src\" />
-      
+
+    <!-- veil C++ enclave static lib -->
     <file src="$vbsenclave_sdk_enclave_x64_Release_lib$" target="lib\native\x64"/>
     <file src="$vbsenclave_sdk_enclave_ARM64_Release_lib$" target="lib\native\arm64"/>
     <file src="$vbsenclave_sdk_enclave_x64_Debug_lib$" target="lib\native\x64"/>
     <file src="$vbsenclave_sdk_enclave_ARM64_Debug_lib$" target="lib\native\arm64"/>
-      
+    <file src="$vbsenclave_sdk_enclave_x64_Release_pdb$" target="lib\native\x64"/>
+    <file src="$vbsenclave_sdk_enclave_ARM64_Release_pdb$" target="lib\native\arm64"/>
+    <file src="$vbsenclave_sdk_enclave_x64_Debug_pdb$" target="lib\native\x64"/>
+    <file src="$vbsenclave_sdk_enclave_ARM64_Debug_pdb$" target="lib\native\arm64"/>
+
+    <!-- veil C++ host static lib -->
     <file src="$vbsenclave_sdk_host_x64_Release_lib$" target="lib\native\x64"/>
     <file src="$vbsenclave_sdk_host_ARM64_Release_lib$" target="lib\native\arm64"/>
     <file src="$vbsenclave_sdk_host_x64_Debug_lib$" target="lib\native\x64"/>
     <file src="$vbsenclave_sdk_host_ARM64_Debug_lib$" target="lib\native\arm64"/>
-      
+    <file src="$vbsenclave_sdk_host_x64_Release_pdb$" target="lib\native\x64"/>
+    <file src="$vbsenclave_sdk_host_ARM64_Release_pdb$" target="lib\native\arm64"/>
+    <file src="$vbsenclave_sdk_host_x64_Debug_pdb$" target="lib\native\x64"/>
+    <file src="$vbsenclave_sdk_host_ARM64_Debug_pdb$" target="lib\native\arm64"/>
+
+    <!-- veil C++ support static lib -->
     <file src="$vbsenclave_sdk_cpp_support_x64_Release_lib$" target="lib\native\x64"/>
     <file src="$vbsenclave_sdk_cpp_support_ARM64_Release_lib$" target="lib\native\arm64"/>
     <file src="$vbsenclave_sdk_cpp_support_x64_Debug_lib$" target="lib\native\x64"/>
     <file src="$vbsenclave_sdk_cpp_support_ARM64_Debug_lib$" target="lib\native\arm64"/>
+    <file src="$vbsenclave_sdk_cpp_support_x64_Release_pdb$" target="lib\native\x64"/>
+    <file src="$vbsenclave_sdk_cpp_support_ARM64_Release_pdb$" target="lib\native\arm64"/>
+    <file src="$vbsenclave_sdk_cpp_support_x64_Debug_pdb$" target="lib\native\x64"/>
+    <file src="$vbsenclave_sdk_cpp_support_ARM64_Debug_pdb$" target="lib\native\arm64"/>
       
     <file src="..\..\..\README.md"/>
   </files>

--- a/src/VbsEnclaveSDK/src/veil_nuget/Nuget/Microsoft.Windows.VbsEnclave.SDK.targets
+++ b/src/VbsEnclaveSDK/src/veil_nuget/Nuget/Microsoft.Windows.VbsEnclave.SDK.targets
@@ -7,9 +7,9 @@
          -->
         <VbsEnclaveSdkPackageDir>$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)))..\..\</VbsEnclaveSdkPackageDir>
         <VbsEnclaveSDKSrc>$(VbsEnclaveSdkPackageDir)src</VbsEnclaveSDKSrc>
-        <VbsEnclaveSdkCppSupportLib>$(VbsEnclaveSdkPackageDir)lib\native\$(Platform)\veil_enclave_cpp_support_lib.lib</VbsEnclaveSdkCppSupportLib>
-        <VbsEnclaveNugetPackEnclaveLibPath>$(VbsEnclaveSdkPackageDir)lib\native\$(Platform)\veil_enclave_lib.lib</VbsEnclaveNugetPackEnclaveLibPath>
-        <VbsEnclaveNugetPackHostLibPath>$(VbsEnclaveSdkPackageDir)lib\native\$(Platform)\veil_host_lib.lib</VbsEnclaveNugetPackHostLibPath>
+        <VbsEnclaveSdkCppSupportLib>$(VbsEnclaveSdkPackageDir)lib\native\$(Platform)\veil_enclave_cpp_support_$(Platform)_$(Configuration)_lib.lib</VbsEnclaveSdkCppSupportLib>
+        <VbsEnclaveNugetPackEnclaveLibPath>$(VbsEnclaveSdkPackageDir)lib\native\$(Platform)\veil_enclave_$(Platform)_$(Configuration)_lib.lib</VbsEnclaveNugetPackEnclaveLibPath>
+        <VbsEnclaveNugetPackHostLibPath>$(VbsEnclaveSdkPackageDir)lib\native\$(Platform)\veil_host_$(Platform)_$(Configuration)_lib.lib</VbsEnclaveNugetPackHostLibPath>
     </PropertyGroup>
 
     <ItemDefinitionGroup>

--- a/src/VbsEnclaveSDK/src/veil_nuget/Nuget/VisualStudioUiBuild.targets
+++ b/src/VbsEnclaveSDK/src/veil_nuget/Nuget/VisualStudioUiBuild.targets
@@ -10,11 +10,14 @@
         <VbsEnclaveNugetPackCppSupportPath>$(OutDir)veil_enclave_cpp_support_$(Platform)_$(Configuration)_lib.lib</VbsEnclaveNugetPackCppSupportPath>
         <VbsEnclaveNugetPackEnclaveLibPath>$(OutDir)veil_enclave_$(Platform)_$(Configuration)_lib.lib</VbsEnclaveNugetPackEnclaveLibPath>
         <VbsEnclaveNugetPackHostLibPath>$(OutDir)veil_host_lib\veil_host_$(Platform)_$(Configuration)_lib.lib</VbsEnclaveNugetPackHostLibPath>
-        <VbsEnclaveNugetPackProperties>target_version=$(VbsEnclaveSDKNugetPackVersionNumber);vbsenclave_sdk_enclave_$(Platform)_$(Configuration)_lib=$(VbsEnclaveNugetPackEnclaveLibPath);vbsenclave_sdk_host_$(Platform)_$(Configuration)_lib=$(VbsEnclaveNugetPackHostLibPath);vbsenclave_sdk_cpp_support_$(Platform)_$(Configuration)_lib=$(VbsEnclaveNugetPackCppSupportPath);</VbsEnclaveNugetPackProperties>
+        <VbsEnclaveNugetPackCppSupportPdbPath>$(OutDir)veil_enclave_cpp_support_$(Platform)_$(Configuration)_lib.pdb</VbsEnclaveNugetPackCppSupportPdbPath>
+        <VbsEnclaveNugetPackEnclaveLibPdbPath>$(OutDir)veil_enclave_$(Platform)_$(Configuration)_lib.pdb</VbsEnclaveNugetPackEnclaveLibPdbPath>
+        <VbsEnclaveNugetPackHostLibPdbPath>$(OutDir)veil_host_lib\veil_host_$(Platform)_$(Configuration)_lib.pdb</VbsEnclaveNugetPackHostLibPdbPath>
+        <VbsEnclaveNugetPackProperties>target_version=$(VbsEnclaveSDKNugetPackVersionNumber);vbsenclave_sdk_enclave_$(Platform)_$(Configuration)_lib=$(VbsEnclaveNugetPackEnclaveLibPath);vbsenclave_sdk_host_$(Platform)_$(Configuration)_lib=$(VbsEnclaveNugetPackHostLibPath);vbsenclave_sdk_cpp_support_$(Platform)_$(Configuration)_lib=$(VbsEnclaveNugetPackCppSupportPath);;vbsenclave_sdk_enclave_$(Platform)_$(Configuration)_pdb=$(VbsEnclaveNugetPackEnclaveLibPdbPath);vbsenclave_sdk_host_$(Platform)_$(Configuration)_pdb=$(VbsEnclaveNugetPackHostLibPdbPath);vbsenclave_sdk_cpp_support_$(Platform)_$(Configuration)_pdb=$(VbsEnclaveNugetPackCppSupportPdbPath);</VbsEnclaveNugetPackProperties>
         <VbsEnclaveNugetPackOutputDirectory>$(SolutionDir)_build</VbsEnclaveNugetPackOutputDirectory>
         <VbsEnclaveNugetPackScriptFile>$(SolutionDir)..\..\buildScripts\PackageNuget.ps1</VbsEnclaveNugetPackScriptFile>
     </PropertyGroup>
-    
+
     <!-- 
         Targets in this file should only run when building in visual studio and should not be ran when building
         the solution using the <repo path>\buildScripts\build.ps1 file on the commandline. That file handles

--- a/src/VbsEnclaveSDK/src/veil_nuget/Nuget/VisualStudioUiBuild.targets
+++ b/src/VbsEnclaveSDK/src/veil_nuget/Nuget/VisualStudioUiBuild.targets
@@ -2,10 +2,15 @@
     <PropertyGroup>
         <VbsEnclaveNugetSpecFilePath>$(ProjectDir)Nuget\Microsoft.Windows.VbsEnclave.SDK.nuspec</VbsEnclaveNugetSpecFilePath>
         <VbsEnclaveSDKNugetPackVersionNumber>0.0.0</VbsEnclaveSDKNugetPackVersionNumber>
-        <VbsEnclaveNugetPackCppSupportPath>$(OutDir)veil_enclave_cpp_support_lib.lib</VbsEnclaveNugetPackCppSupportPath>
-        <VbsEnclaveNugetPackEnclaveLibPath>$(OutDir)veil_enclave_lib.lib</VbsEnclaveNugetPackEnclaveLibPath>
-        <VbsEnclaveNugetPackHostLibPath>$(OutDir)veil_host_lib\veil_host_lib.lib</VbsEnclaveNugetPackHostLibPath>
-        <VbsEnclaveNugetPackProperties>target_version=$(VbsEnclaveSDKNugetPackVersionNumber);vbsenclave_sdk_enclave_$(Platform)_lib=$(VbsEnclaveNugetPackEnclaveLibPath);vbsenclave_sdk_host_$(Platform)_lib=$(VbsEnclaveNugetPackHostLibPath);vbsenclave_sdk_cpp_support_$(Platform)_lib=$(VbsEnclaveNugetPackCppSupportPath);</VbsEnclaveNugetPackProperties>
+
+        <!-- 
+            Note: Currently we only support building one platform and one configuration at a time when using the Visual Studio UI. If you need the CodeGenerator
+            nuget package to contain both arm64 and x64 and debug and release libraries use the build.ps1 script in <veil-solution-root>\buildScripts
+        -->
+        <VbsEnclaveNugetPackCppSupportPath>$(OutDir)veil_enclave_cpp_support_$(Platform)_$(Configuration)_lib.lib</VbsEnclaveNugetPackCppSupportPath>
+        <VbsEnclaveNugetPackEnclaveLibPath>$(OutDir)veil_enclave_$(Platform)_$(Configuration)_lib.lib</VbsEnclaveNugetPackEnclaveLibPath>
+        <VbsEnclaveNugetPackHostLibPath>$(OutDir)veil_host_lib\veil_host_$(Platform)_$(Configuration)_lib.lib</VbsEnclaveNugetPackHostLibPath>
+        <VbsEnclaveNugetPackProperties>target_version=$(VbsEnclaveSDKNugetPackVersionNumber);vbsenclave_sdk_enclave_$(Platform)_$(Configuration)_lib=$(VbsEnclaveNugetPackEnclaveLibPath);vbsenclave_sdk_host_$(Platform)_$(Configuration)_lib=$(VbsEnclaveNugetPackHostLibPath);vbsenclave_sdk_cpp_support_$(Platform)_$(Configuration)_lib=$(VbsEnclaveNugetPackCppSupportPath);</VbsEnclaveNugetPackProperties>
         <VbsEnclaveNugetPackOutputDirectory>$(SolutionDir)_build</VbsEnclaveNugetPackOutputDirectory>
         <VbsEnclaveNugetPackScriptFile>$(SolutionDir)..\..\buildScripts\PackageNuget.ps1</VbsEnclaveNugetPackScriptFile>
     </PropertyGroup>


### PR DESCRIPTION
### Background

- Previously the nuget package only contained static libs that were built for a specific configuration. Either `Release` or `Debug`. What this meant is that the CRT the static lib was built with could result in a mismatch depending on what configuration the consuming project is being built with.

### What changed

- I updated the build script, nuspec and nuget pack values to include both `Release` and `Debug` static libs in the nuget package.
- I also updated the OneBranch pipeline to do the same thing. Although once this PR goes in I'll have to spin up new nuget packages. 
- I also added the `pdb` files to the nuget package.

### How was it tested.
- New build script now builds both `x64` and `arm64`  by default. I confirmed that after running the script the nuget packages contains both release and debug static libs. 
- Confirmed sampleApps solution can be built using the nuget package, in both release and debug.
- once this goes in I'll run the pipeline, if it fails due to a missed typo or something like that, I'll submit a PR to update it and rerun the pipeline.



