### PR TITLE
remove build configuration left over in yml

### DIFF
--- a/AzurePipelineTemplates/jobs/CodeGenBuildJob.yml
+++ b/AzurePipelineTemplates/jobs/CodeGenBuildJob.yml
@@ -21,7 +21,6 @@ jobs:
     ob_outputDirectory: '$(Build.SourcesDirectory)\signed_nuget'   
     ob_artifactBaseName: signed_codegen_nuget_package 
     BaseBuildDirectory: $(Build.SourcesDirectory)\_build
-    BuildConfiguration: ${{ parameters.BuildConfiguration }}
     x64ReleaseBuildLocation: $(BaseBuildDirectory)\x64\Release
     x64DebugBuildLocation: $(BaseBuildDirectory)\x64\Debug
     Arm64ReleaseBuildLocation: $(BaseBuildDirectory)\ARM64\Release


### PR DESCRIPTION
remove build configuration left over in yml. Build configuration no longer exists in the ymls parameters key value pair list.