### PR TITLE
fix cpp support lib and fix pdb strings in pipeline

### DIFF
--- a/AzurePipelineTemplates/jobs/CodeGenBuildJob.yml
+++ b/AzurePipelineTemplates/jobs/CodeGenBuildJob.yml
@@ -26,15 +26,15 @@ jobs:
     Arm64ReleaseBuildLocation: $(BaseBuildDirectory)\ARM64\Release
     Arm64DebugBuildLocation: $(BaseBuildDirectory)\ARM64\Debug
 
-    # veil_cpp_support_lib pack args
-    VeilCppSupportLibX64Release: vbsenclave_codegen_cpp_support_x64_Release_lib=$(x64ReleaseBuildLocation)\veil_cpp_support_x64_Release_lib.lib
-    VeilCppSupportPdbX64Release: vbsenclave_codegen_cpp_support_x64_Release_pdb=$(x64ReleaseBuildLocation)\veil_cpp_support_x64_Release_lib.pdb
-    VeilCppSupportLibX64Debug: vbsenclave_codegen_cpp_support_x64_Debug_lib=$(x64DebugBuildLocation)\veil_cpp_support_x64_Debug_lib.lib
-    VeilCppSupportPdbX64Debug: vbsenclave_codegen_cpp_support_x64_Debug_pdb=$(x64DebugBuildLocation)\veil_cpp_support_x64_Debug_lib.pdb
-    VeilCppSupportLibARM64Release: vbsenclave_codegen_cpp_support_ARM64_Release_lib=$(Arm64ReleaseBuildLocation)\veil_cpp_support_ARM64_Release_lib.lib
-    VeilCppSupportPdbARM64Release: vbsenclave_codegen_cpp_support_ARM64_Release_pdb=$(Arm64ReleaseBuildLocation)\veil_cpp_support_ARM64_Release_pdb.pdb
-    VeilCppSupportLibARM64Debug: vbsenclave_codegen_cpp_support_ARM64_Debug_lib=$(Arm64DebugBuildLocation)\veil_cpp_support_ARM64_Debug_lib.lib
-    VeilCppSupportPdbARM64Debug: vbsenclave_codegen_cpp_support_ARM64_Debug_pdb=$(Arm64DebugBuildLocation)\veil_cpp_support_ARM64_Debug_lib.pdb
+    # veil_enclave_cpp_support_lib pack args
+    VeilCppSupportLibX64Release: vbsenclave_codegen_cpp_support_x64_Release_lib=$(x64ReleaseBuildLocation)\veil_enclave_cpp_support_x64_Release_lib.lib
+    VeilCppSupportPdbX64Release: vbsenclave_codegen_cpp_support_x64_Release_pdb=$(x64ReleaseBuildLocation)\veil_enclave_cpp_support_x64_Release_lib.pdb
+    VeilCppSupportLibX64Debug: vbsenclave_codegen_cpp_support_x64_Debug_lib=$(x64DebugBuildLocation)\veil_enclave_cpp_support_x64_Debug_lib.lib
+    VeilCppSupportPdbX64Debug: vbsenclave_codegen_cpp_support_x64_Debug_pdb=$(x64DebugBuildLocation)\veil_enclave_cpp_support_x64_Debug_lib.pdb
+    VeilCppSupportLibARM64Release: vbsenclave_codegen_cpp_support_ARM64_Release_lib=$(Arm64ReleaseBuildLocation)\veil_enclave_cpp_support_ARM64_Release_lib.lib
+    VeilCppSupportPdbARM64Release: vbsenclave_codegen_cpp_support_ARM64_Release_pdb=$(Arm64ReleaseBuildLocation)\veil_enclave_cpp_support_ARM64_Release_lib.pdb
+    VeilCppSupportLibARM64Debug: vbsenclave_codegen_cpp_support_ARM64_Debug_lib=$(Arm64DebugBuildLocation)\veil_enclave_cpp_support_ARM64_Debug_lib.lib
+    VeilCppSupportPdbARM64Debug: vbsenclave_codegen_cpp_support_ARM64_Debug_pdb=$(Arm64DebugBuildLocation)\veil_enclave_cpp_support_ARM64_Debug_lib.pdb
     
   steps:
     - checkout: Vcpkg

--- a/AzurePipelineTemplates/jobs/SdkBuildJob.yml
+++ b/AzurePipelineTemplates/jobs/SdkBuildJob.yml
@@ -50,15 +50,15 @@ jobs:
     VeilHostPdbARM64Release: vbsenclave_sdk_host_ARM64_Release_pdb=$(Arm64ReleaseBuildLocation)\veil_host_lib\veil_host_ARM64_Release_lib.pdb
     VeilHostPdbARM64Debug: vbsenclave_sdk_host_ARM64_Debug_pdb=$(Arm64DebugBuildLocation)\veil_host_lib\veil_host_ARM64_Debug_lib.pdb
     
-    # veil_cpp_support_lib pack args
-    VeilCppSupportLibX64Release: vbsenclave_sdk_cpp_support_x64_Release_lib=$(x64ReleaseBuildLocation)\veil_cpp_support_x64_Release_lib.lib  
-    VeilCppSupportLibX64Debug: vbsenclave_sdk_cpp_support_x64_Debug_lib=$(x64DebugBuildLocation)\veil_cpp_support_x64_Debug_lib.lib
-    VeilCppSupportLibARM64Release: vbsenclave_sdk_cpp_support_ARM64_Release_lib=$(Arm64ReleaseBuildLocation)\veil_cpp_support_ARM64_Release_lib.lib
-    VeilCppSupportLibARM64Debug: vbsenclave_sdk_cpp_support_ARM64_Debug_lib=$(Arm64DebugBuildLocation)\veil_cpp_support_ARM64_Debug_lib.lib
-    VeilCppSupportPdbX64Release: vbsenclave_sdk_cpp_support_x64_Release_pdb=$(x64ReleaseBuildLocation)\veil_cpp_support_x64_Release_lib.pdb  
-    VeilCppSupportPdbX64Debug: vbsenclave_sdk_cpp_support_x64_Debug_pdb=$(x64DebugBuildLocation)\veil_cpp_support_x64_Debug_lib.pdb
-    VeilCppSupportPdbARM64Release: vbsenclave_sdk_cpp_support_ARM64_Release_pdb=$(Arm64ReleaseBuildLocation)\veil_cpp_support_ARM64_Release_lib.pdb
-    VeilCppSupportPdbARM64Debug: vbsenclave_sdk_cpp_support_ARM64_Debug_pdb=$(Arm64DebugBuildLocation)\veil_cpp_support_ARM64_Debug_lib.pdb
+    # veil_enclave_cpp_support_lib pack args
+    VeilCppSupportLibX64Release: vbsenclave_sdk_cpp_support_x64_Release_lib=$(x64ReleaseBuildLocation)\veil_enclave_cpp_support_x64_Release_lib.lib  
+    VeilCppSupportLibX64Debug: vbsenclave_sdk_cpp_support_x64_Debug_lib=$(x64DebugBuildLocation)\veil_enclave_cpp_support_x64_Debug_lib.lib
+    VeilCppSupportLibARM64Release: vbsenclave_sdk_cpp_support_ARM64_Release_lib=$(Arm64ReleaseBuildLocation)\veil_enclave_cpp_support_ARM64_Release_lib.lib
+    VeilCppSupportLibARM64Debug: vbsenclave_sdk_cpp_support_ARM64_Debug_lib=$(Arm64DebugBuildLocation)\veil_enclave_cpp_support_ARM64_Debug_lib.lib
+    VeilCppSupportPdbX64Release: vbsenclave_sdk_cpp_support_x64_Release_pdb=$(x64ReleaseBuildLocation)\veil_enclave_cpp_support_x64_Release_lib.pdb  
+    VeilCppSupportPdbX64Debug: vbsenclave_sdk_cpp_support_x64_Debug_pdb=$(x64DebugBuildLocation)\veil_enclave_cpp_support_x64_Debug_lib.pdb
+    VeilCppSupportPdbARM64Release: vbsenclave_sdk_cpp_support_ARM64_Release_pdb=$(Arm64ReleaseBuildLocation)\veil_enclave_cpp_support_ARM64_Release_lib.pdb
+    VeilCppSupportPdbARM64Debug: vbsenclave_sdk_cpp_support_ARM64_Debug_pdb=$(Arm64DebugBuildLocation)\veil_enclave_cpp_support_ARM64_Debug_lib.pdb
     
   steps:
    # Download the nupkg file from the codegen job


### PR DESCRIPTION
Unfortunately wasn't able to get a test going yesterday as there was a OneBranch icm outage delaying pipeline runs, but now the pipelines are working. I was able to test out this change and run the updated template in a non prod pipeline. This succeeded and you can see the results [here](https://microsoft.visualstudio.com/Dart/_build/results?buildId=122841745&view=results). Also confirmed the produced nuget packages contain both release and debug static libs, and the targets files use `$(Platform)` and `$(Configuration)` to point to the correct lib at build time.

- Another thing I did was test the unsigned nuget package generated from the non prod pipeline, to confirm the sample app can be built in release and debug with it. On both arm64 and x64 platforms

### What changed
- `veil_cpp_support_`platform_configuration was supposed to be `veil_enclave_cpp_support_`platform_configuration. Note the addition of the word **enclave**.
- in `AzurePipelineTemplates/jobs/CodeGenBuildJob.yml` I had `veil_cpp_support_ARM64_Release_pdb.pdb` instead of `veil_cpp_support_ARM64_Release_lib.pdb`. Note: at the end `_pdb` was previously used instead of `_lib`.

Once this is in I'll run it on the prod pipeline and we should have a new signed 0.0.2-preview nuget.