### PR TITLE
Allow user to write logs into their chosen dir, default to cwd

### DIFF
--- a/SampleApps/SampleApps/README.md
+++ b/SampleApps/SampleApps/README.md
@@ -70,4 +70,4 @@ https://learn.microsoft.com/windows/win32/trusted-execution/vbs-enclaves-dev-gui
 
 	- We support telemetry strings from the Enclave that are 2048 chars or shorter. Refer to telemetry usage in the 
 sample app.
-	- Telemetry files are stored in current working directory.	
+	- Telemetry files are stored in user specified dir or the current working directory (by default).	

--- a/SampleApps/SampleApps/README.md
+++ b/SampleApps/SampleApps/README.md
@@ -70,4 +70,4 @@ https://learn.microsoft.com/windows/win32/trusted-execution/vbs-enclaves-dev-gui
 
 	- We support telemetry strings from the Enclave that are 2048 chars or shorter. Refer to telemetry usage in the 
 sample app.
-	- Telemetry files are stored in c:\VeilLogs.	
+	- Telemetry files are stored in current working directory.	

--- a/SampleApps/SampleApps/SampleApp1/main.cpp
+++ b/SampleApps/SampleApps/SampleApp1/main.cpp
@@ -279,8 +279,8 @@ int mainEncryptDecrpyt(uint32_t activityLevel)
 {
     int choice;
     std::wstring input;
-    const std::wstring encrytedKeyDirPath = std::filesystem::current_path().c_str();
-    const std::wstring encryptedDataDirPath = std::filesystem::current_path().c_str();
+    const std::wstring encrytedKeyDirPath = std::filesystem::current_path().wstring();
+    const std::wstring encryptedDataDirPath = std::filesystem::current_path().wstring();
     std::wstring encryptedInputFilePath = encryptedDataDirPath + L"\\encrypted";
     std::wstring tagFilePath = encrytedKeyDirPath + L"\\tag";
     bool programExecuted = false;
@@ -418,8 +418,8 @@ int mainEncryptDecrpytThreadpool(uint32_t activityLevel)
 
     int choice;
     std::wstring input1, input2;
-    const std::wstring encrytedKeyDirPath = std::filesystem::current_path().c_str();
-    const std::wstring encryptedDataDirPath = std::filesystem::current_path().c_str();
+    const std::wstring encrytedKeyDirPath = std::filesystem::current_path().wstring();
+    const std::wstring encryptedDataDirPath = std::filesystem::current_path().wstring();
     std::wstring encryptedInputFilePath = encryptedDataDirPath + L"\\encrypted";
     std::wstring tagFilePath = encrytedKeyDirPath + L"\\tag";
     bool programExecuted = false;

--- a/SampleApps/SampleApps/SampleApp1/main.cpp
+++ b/SampleApps/SampleApps/SampleApp1/main.cpp
@@ -279,10 +279,10 @@ int mainEncryptDecrpyt(uint32_t activityLevel)
 {
     int choice;
     std::wstring input;
-    const std::wstring encrytedKeyDirPath = std::filesystem::current_path().wstring();
+    const std::wstring encryptedKeyDirPath = std::filesystem::current_path().wstring();
     const std::wstring encryptedDataDirPath = std::filesystem::current_path().wstring();
     std::wstring encryptedInputFilePath = encryptedDataDirPath + L"\\encrypted";
-    std::wstring tagFilePath = encrytedKeyDirPath + L"\\tag";
+    std::wstring tagFilePath = encryptedKeyDirPath + L"\\tag";
     bool programExecuted = false;
 
     veil::vtl0::logger::logger veilLog(
@@ -309,7 +309,7 @@ int mainEncryptDecrpyt(uint32_t activityLevel)
     constexpr PCWSTR keyMoniker = L"MyEncryptionKey-001";
 
     // File with secured encryption key bytes
-    auto keyFilePath = std::filesystem::path(encrytedKeyDirPath) / keyMoniker;
+    auto keyFilePath = std::filesystem::path(encryptedKeyDirPath) / keyMoniker;
 
     do
     {
@@ -418,10 +418,10 @@ int mainEncryptDecrpytThreadpool(uint32_t activityLevel)
 
     int choice;
     std::wstring input1, input2;
-    const std::wstring encrytedKeyDirPath = std::filesystem::current_path().wstring();
+    const std::wstring encryptedKeyDirPath = std::filesystem::current_path().wstring();
     const std::wstring encryptedDataDirPath = std::filesystem::current_path().wstring();
     std::wstring encryptedInputFilePath = encryptedDataDirPath + L"\\encrypted";
-    std::wstring tagFilePath = encrytedKeyDirPath + L"\\tag";
+    std::wstring tagFilePath = encryptedKeyDirPath + L"\\tag";
     bool programExecuted = false;
 
     veil::vtl0::logger::logger veilLog(
@@ -433,7 +433,7 @@ int mainEncryptDecrpytThreadpool(uint32_t activityLevel)
     constexpr PCWSTR keyMoniker = L"MyEncryptionKey-001";
 
     // File with secured encryption key bytes
-    auto keyFilePath = std::filesystem::path(encrytedKeyDirPath) / keyMoniker;
+    auto keyFilePath = std::filesystem::path(encryptedKeyDirPath) / keyMoniker;
 
     do
     {

--- a/SampleApps/SampleApps/SampleApp1/main.cpp
+++ b/SampleApps/SampleApps/SampleApp1/main.cpp
@@ -279,7 +279,7 @@ int mainEncryptDecrpyt(uint32_t activityLevel)
 {
     int choice;
     std::wstring input;
-    const std::wstring encrytedKeyDirPath = std::filesystem::current_path().c_str();;
+    const std::wstring encrytedKeyDirPath = std::filesystem::current_path().c_str();
     const std::wstring encryptedDataDirPath = std::filesystem::current_path().c_str();
     std::wstring encryptedInputFilePath = encryptedDataDirPath + L"\\encrypted";
     std::wstring tagFilePath = encrytedKeyDirPath + L"\\tag";

--- a/SampleApps/SampleApps/SampleApps.sln
+++ b/SampleApps/SampleApps/SampleApps.sln
@@ -51,4 +51,7 @@ Global
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2CC90DE8-BC52-49A9-9902-2F8382149CFC}
 	EndGlobalSection
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		packages\Microsoft.Windows.VbsEnclaveTooling.0.0.0\src\VbsEnclaveSDK\veil_any_inc\veil_any_inc.vcxitems*{d2c762e2-0de1-4f72-98c9-75f7bd69d17e}*SharedItemsImports = 4
+	EndGlobalSection
 EndGlobal

--- a/SampleApps/SampleApps/SampleEnclave/my_exports.cpp
+++ b/SampleApps/SampleApps/SampleEnclave/my_exports.cpp
@@ -292,7 +292,7 @@ HRESULT VbsEnclave::VTL1_Declarations::RunEncryptionKeyExample_CreateEncryptionK
     
     auto activityLevel = (veil::any::logger::eventLevel)activity_level;
 
-    veil::vtl1::logger::implementation::add_log_from_enclave(
+    veil::vtl1::logger::add_log_from_enclave(
         L"[Enclave] In RunEncryptionKeyExample_CreateEncryptionKeyImpl", 
         veil::any::logger::eventLevel::EVENT_LEVEL_CRITICAL,
         activityLevel,
@@ -301,7 +301,7 @@ HRESULT VbsEnclave::VTL1_Declarations::RunEncryptionKeyExample_CreateEncryptionK
     debug_print("");
     debug_print(L"[Create flow]");
     debug_print("");
-    veil::vtl1::logger::implementation::add_log_from_enclave(
+    veil::vtl1::logger::add_log_from_enclave(
         L"[Enclave] Create flow", 
         veil::any::logger::eventLevel::EVENT_LEVEL_VERBOSE,
         activityLevel,
@@ -311,7 +311,7 @@ HRESULT VbsEnclave::VTL1_Declarations::RunEncryptionKeyExample_CreateEncryptionK
 
     // Generate our encryption key
     debug_print(L"1. Generating our encryption key");
-    veil::vtl1::logger::implementation::add_log_from_enclave(
+    veil::vtl1::logger::add_log_from_enclave(
         L"[Enclave] Generating our encryption key",
         veil::any::logger::eventLevel::EVENT_LEVEL_INFO,
         activityLevel,
@@ -319,7 +319,7 @@ HRESULT VbsEnclave::VTL1_Declarations::RunEncryptionKeyExample_CreateEncryptionK
     auto encryptionKeyBytes = veil::vtl1::crypto::generate_symmetric_key_bytes();
     debug_print(L" ...CHECKPOINT: encryption key byte count: %d", encryptionKeyBytes.size());
     std::wstring logSizeStr = std::to_wstring(encryptionKeyBytes.size());
-    veil::vtl1::logger::implementation::add_log_from_enclave(
+    veil::vtl1::logger::add_log_from_enclave(
         L"[Enclave] Encryption key byte count: " + logSizeStr,
         veil::any::logger::eventLevel::EVENT_LEVEL_CRITICAL,
         activityLevel,
@@ -328,7 +328,7 @@ HRESULT VbsEnclave::VTL1_Declarations::RunEncryptionKeyExample_CreateEncryptionK
     
     // Seal it so only our enclave may open it
     debug_print(L"4. Sealing the serialized key material for our enclave only");
-    veil::vtl1::logger::implementation::add_log_from_enclave(
+    veil::vtl1::logger::add_log_from_enclave(
         L"[Enclave] Sealing the serialized key material for our enclave only",
         veil::any::logger::eventLevel::EVENT_LEVEL_INFO,
         activityLevel,
@@ -336,7 +336,7 @@ HRESULT VbsEnclave::VTL1_Declarations::RunEncryptionKeyExample_CreateEncryptionK
     auto sealedKeyMaterial = veil::vtl1::crypto::seal_data(encryptionKeyBytes, ENCLAVE_IDENTITY_POLICY_SEAL_SAME_IMAGE, ENCLAVE_RUNTIME_POLICY_ALLOW_FULL_DEBUG);
     debug_print(L" ...CHECKPOINT: sealed key material byte count: %d", sealedKeyMaterial.size());
     logSizeStr = std::to_wstring(sealedKeyMaterial.size());
-    veil::vtl1::logger::implementation::add_log_from_enclave(
+    veil::vtl1::logger::add_log_from_enclave(
         L"[Enclave] Sealed key material byte count: " + logSizeStr,
         veil::any::logger::eventLevel::EVENT_LEVEL_CRITICAL,
         activityLevel,
@@ -372,7 +372,7 @@ HRESULT RunEncryptionKeyExample_LoadEncryptionKeyImpl(
 
     auto activityLevel = (veil::any::logger::eventLevel)activity_level;
 
-    veil::vtl1::logger::implementation::add_log_from_enclave(
+    veil::vtl1::logger::add_log_from_enclave(
         L"[Enclave] In RunEncryptionKeyExample_LoadEncryptionKeyImpl",
         veil::any::logger::eventLevel::EVENT_LEVEL_CRITICAL,
         activityLevel,

--- a/src/VbsEnclaveSDK/src/veil_enclave_lib/logger.vtl1.h
+++ b/src/VbsEnclaveSDK/src/veil_enclave_lib/logger.vtl1.h
@@ -15,18 +15,18 @@ namespace veil::vtl1::logger
         {
             void add_log(std::wstring_view log, std::wstring_view logFilePath);
         }
+    }
 
-        inline void add_log_from_enclave(
+    inline void add_log_from_enclave(
             std::wstring_view log,
             veil::any::logger::eventLevel logLevel,
             veil::any::logger::eventLevel runtimeLogLevel,
             std::wstring_view logFilePath)
-        {
+    {
 
-            if ((int)logLevel <= (int)runtimeLogLevel)
-            {
-                implementation::callouts::add_log(log, logFilePath);
-            }
+        if ((int)logLevel <= (int)runtimeLogLevel)
+        {
+            implementation::callouts::add_log(log, logFilePath);
         }
     }
 }

--- a/src/VbsEnclaveSDK/src/veil_host_lib/logger.vtl0.h
+++ b/src/VbsEnclaveSDK/src/veil_host_lib/logger.vtl0.h
@@ -49,9 +49,9 @@ namespace veil::vtl0
                 return modified;
             }
 
-            void SetLogFilePath()
-            {
-                logFilePath = L"c:\\VeilLogs\\" + ReplaceForbiddenFilenameChars(CreateTimestamp()) + L".txt";
+            void SetLogFilePath()  
+            {  
+               logFilePath = std::filesystem::current_path().wstring() + L"\\" + ReplaceForbiddenFilenameChars(CreateTimestamp()) + L".txt";  
             }
 
             static std::wstring CreateTimestamp()

--- a/src/VbsEnclaveSDK/src/veil_host_lib/logger.vtl0.h
+++ b/src/VbsEnclaveSDK/src/veil_host_lib/logger.vtl0.h
@@ -12,11 +12,6 @@
 
 #include "..\veil_any_inc\logger.any.h"
 
-namespace veil::vtl0::implementation::callbacks
-{
-    void* add_log(void* args) noexcept;
-}
-
 namespace veil::vtl0
 {
     namespace logger
@@ -47,11 +42,6 @@ namespace veil::vtl0
                 }
 
                 return modified;
-            }
-
-            void SetLogFilePath()  
-            {  
-               logFilePath = std::filesystem::current_path().wstring() + L"\\" + ReplaceForbiddenFilenameChars(CreateTimestamp()) + L".txt";  
             }
 
             static std::wstring CreateTimestamp()
@@ -96,10 +86,19 @@ namespace veil::vtl0
 
             public:
             logger(const std::wstring& providerName,
-                const std::wstring& guidStr,
-                const veil::any::logger::eventLevel level) : provider(providerName), guid(guidStr), logLevel(level)
+               const std::wstring& guidStr,
+               const veil::any::logger::eventLevel level,
+               const std::filesystem::path& logDirectory = std::filesystem::path()) : provider(providerName), guid(guidStr), logLevel(level)
             {
-                SetLogFilePath();
+               if (!logDirectory.empty())
+               {
+                   logFilePath = logDirectory.wstring() + L"\\" + ReplaceForbiddenFilenameChars(CreateTimestamp()) + L".txt";
+               }
+               else
+               {
+                   // Default to the current working directory if no directory is provided
+                   logFilePath = std::filesystem::current_path().wstring() + L"\\" + ReplaceForbiddenFilenameChars(CreateTimestamp()) + L".txt";
+               }
             }
 
             void AddTimestampedLog(const std::wstring& log, const veil::any::logger::eventLevel level) // Called from Host


### PR DESCRIPTION
This PR extends the logging subsystem to allow specifying a custom output directory (defaulting to the current working directory) and updates sample apps and documentation to match.
•	Added an optional logDirectory parameter to the logger constructor, defaulting to std::filesystem::current_path()
•	Updated sample applications to use .wstring() instead of .c_str() for std::filesystem::path
•	Revised README to reflect that telemetry files are now stored in the current working directory