### PR TITLE
Fix build for tooling executable and unit tests projects

### DIFF
--- a/src/ToolingExecutable/ToolingExecutable.vcxproj
+++ b/src/ToolingExecutable/ToolingExecutable.vcxproj
@@ -105,11 +105,12 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <MultiProcessorCompilation>false</MultiProcessorCompilation>
-	  <ControlFlowGuard>Guard</ControlFlowGuard>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <AdditionalDependencies>$(CoreLibraryDependencies);%(AdditionalDependencies);$(OutDir)ToolingSharedLibrary.lib</AdditionalDependencies>
-	  <ControlFlowGuard>Guard</ControlFlowGuard>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
       <AdditionalOptions>/DYNAMICBASE %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
@@ -127,11 +128,12 @@
       <BuildStlModules>false</BuildStlModules>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-	  <ControlFlowGuard>Guard</ControlFlowGuard>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <AdditionalDependencies>$(CoreLibraryDependencies);%(AdditionalDependencies);$(OutDir)ToolingSharedLibrary.lib</AdditionalDependencies>
-	  <ControlFlowGuard>Guard</ControlFlowGuard>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
       <AdditionalOptions>/DYNAMICBASE %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
@@ -159,7 +161,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>$(CoreLibraryDependencies);%(AdditionalDependencies);$(OutDir)ToolingSharedLibrary.lib</AdditionalDependencies>
-	  <ControlFlowGuard>Guard</ControlFlowGuard>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
       <AdditionalOptions>/DYNAMICBASE %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
@@ -178,7 +180,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
-	  <ControlFlowGuard>Guard</ControlFlowGuard>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -186,7 +188,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>$(CoreLibraryDependencies);%(AdditionalDependencies);$(OutDir)ToolingSharedLibrary.lib</AdditionalDependencies>
-	  <ControlFlowGuard>Guard</ControlFlowGuard>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
       <AdditionalOptions>/DYNAMICBASE %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>

--- a/tests/UnitTests/UnitTests.vcxproj
+++ b/tests/UnitTests/UnitTests.vcxproj
@@ -107,14 +107,15 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
-	  <ControlFlowGuard>Guard</ControlFlowGuard>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>$(CoreLibraryDependencies);%(AdditionalDependencies);$(OutDir)ToolingSharedLibrary.lib
  </AdditionalDependencies>
-	  <ControlFlowGuard>Guard</ControlFlowGuard>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
       <AdditionalOptions>/DYNAMICBASE %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
@@ -129,14 +130,15 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
-	  <ControlFlowGuard>Guard</ControlFlowGuard>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>$(CoreLibraryDependencies);%(AdditionalDependencies);$(OutDir)ToolingSharedLibrary.lib
  </AdditionalDependencies>
-	  <ControlFlowGuard>Guard</ControlFlowGuard>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
       <AdditionalOptions>/DYNAMICBASE %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
@@ -153,7 +155,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
-	  <ControlFlowGuard>Guard</ControlFlowGuard>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -162,7 +164,7 @@
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>$(CoreLibraryDependencies);%(AdditionalDependencies);$(OutDir)ToolingSharedLibrary.lib
  </AdditionalDependencies>
-	  <ControlFlowGuard>Guard</ControlFlowGuard>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
       <AdditionalOptions>/DYNAMICBASE %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
@@ -179,7 +181,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
-	  <ControlFlowGuard>Guard</ControlFlowGuard>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -188,7 +190,7 @@
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>$(CoreLibraryDependencies);%(AdditionalDependencies);$(OutDir)ToolingSharedLibrary.lib
  </AdditionalDependencies>
-	  <ControlFlowGuard>Guard</ControlFlowGuard>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
       <AdditionalOptions>/DYNAMICBASE %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>


### PR DESCRIPTION
Noticed when I tried to run the build script I got an error `error D8016: '/ZI' and '/guard:cf' command-line options are incompatible `. Basically, all it means is that the `guard:cf` flag can't be used with `Edit and continue` which is what the `/ZI` flag enables. 

`/ZI : specifies that the debugging info generated by the compiler is set for "Program Database and Edit and Continue`
`/Zi : specifies that the debugging info generated by the compiler is set for only  "Program Database"`

### What changed
- I updated the `/ZI` flag to use `/Zi` instead for all platforms/configurations for the executable and unit test projects. (Used VS UI)

### How was it tested
- Confirmed after running the build script that the error was resolved and the build was successful.
![image](https://github.com/user-attachments/assets/1b3319a7-495f-410e-acec-2f511f2e32b2)

### TODO
- I added a new issue so we don't forget to create a PR pipeline #96 