### PR TITLE
fix edl parser unit tests 

### DIFF
--- a/tests/UnitTests/TestFiles/ArrayTest.edl
+++ b/tests/UnitTests/TestFiles/ArrayTest.edl
@@ -13,80 +13,80 @@ enclave
     {        
         void ArrayChar(
             [in] char arg1[2],
-            [in, out] char arg2[2][2],
-            [out] char arg3[3][3],
+            [in, out] char arg2[2],
+            [out] char arg3[3]
         );
 
         void ArrayWchar_t(
             [in] wchar_t arg1[2],
-            [in, out] wchar_t arg2[2][2],
-            [out] wchar_t arg3[3][3],
+            [in, out] wchar_t arg2[2],
+            [out] wchar_t arg3[3]
         );
 
         void ArrayFloat(
             [in] float arg1[2],
-            [in,out] float arg2[2][2],
-            [out] float arg3[3][3],
+            [in,out] float arg2[2],
+            [out] float arg3[3]
         );
 
         void ArrayDouble(
             [in] double arg1[2],
-            [in,out] double arg2[2][2],
-            [out] double arg3[3][3],
+            [in,out] double arg2[2],
+            [out] double arg3[3]
         );
 
         void ArraySize_t(
             [in] size_t arg1[2],
-            [in,out] size_t arg2[2][2],
-            [out] size_t arg3[3][3],
+            [in,out] size_t arg2[2],
+            [out] size_t arg3[3]
         );
         
         void ArrayInt8_t(
             [in] int8_t arg1[2],
-            [in,out] int8_t arg2[2][2],
-            [out] int8_t arg3[3][3],
+            [in,out] int8_t arg2[2],
+            [out] int8_t arg3[3]
         );
         
         void ArrayInt16_t(
             [in] int16_t arg1[2],
-            [in,out] int16_t arg2[2][2],
-            [out] int16_t arg3[3][3],
+            [in,out] int16_t arg2[2],
+            [out] int16_t arg3[3]
         );
 
         void ArrayInt32_t(
             [in] int32_t arg1[2],
-            [in,out] int32_t arg2[2][2],
-            [out] int32_t arg3[3][3],
+            [in,out] int32_t arg2[2],
+            [out] int32_t arg3[3]
         );
 
         void ArrayInt64_t(
             [in] int64_t arg1[2],
-            [in,out] int64_t arg2[2][2],
-            [out] int64_t arg3[3][3],
+            [in,out] int64_t arg2[2],
+            [out] int64_t arg3[3]
         );
 
         void ArrayUint8_t(
             [in] uint8_t arg1[2],
-            [in,out] uint8_t arg2[2][2],
-            [out] uint8_t arg3[3][3],
+            [in,out] uint8_t arg2[2],
+            [out] uint8_t arg3[3]
         );
         
         void ArrayUint16_t(
             [in] uint16_t arg1[2],
-            [in,out] uint16_t arg2[2][2],
-            [out] uint16_t arg3[3][3],
+            [in,out] uint16_t arg2[2],
+            [out] uint16_t arg3[3]
         );
 
         void ArrayUint32_t(
             [in] uint32_t arg1[2],
-            [in,out] uint32_t arg2[2][2],
-            [out] uint32_t arg3[3][3],
+            [in,out] uint32_t arg2[2],
+            [out] uint32_t arg3[3]
         );
 
         void ArrayUint64_t(
             [in] uint64_t arg1[2],
-            [in,out] uint64_t arg2[2][2],
-            [out] uint64_t arg3[3][3]
+            [in,out] uint64_t arg2[2],
+            [out] uint64_t arg3[3]
         );
     };
 
@@ -94,80 +94,80 @@ enclave
     {
         void ArrayChar(
             [in] char arg1[2],
-            [in, out] char arg2[2][2],
-            [out] char arg3[3][3],
+            [in, out] char arg2[2],
+            [out] char arg3[3]
         );
 
         void ArrayQchar_t(
             [in] wchar_t arg1[2],
-            [in, out] wchar_t arg2[2][2],
-            [out] wchar_t arg3[3][3],
+            [in, out] wchar_t arg2[2],
+            [out] wchar_t arg3[3]
         );
 
         void ArrayFloat(
             [in] float arg1[2],
-            [in,out] float arg2[2][2],
-            [out] float arg3[3][3],
+            [in,out] float arg2[2],
+            [out] float arg3[3]
         );
 
         void ArrayDouble(
             [in] double arg1[2],
-            [in,out] double arg2[2][2],
-            [out] double arg3[3][3],
+            [in,out] double arg2[2],
+            [out] double arg3[3]
         );
 
         void ArraySize_t(
             [in] size_t arg1[2],
-            [in,out] size_t arg2[2][2],
-            [out] size_t arg3[3][3],
+            [in,out] size_t arg2[2],
+            [out] size_t arg3[3]
        );
         
         void ArrayInt8_t(
             [in] int8_t arg1[2],
-            [in,out] int8_t arg2[2][2],
-            [out] int8_t arg3[3][3],
+            [in,out] int8_t arg2[2],
+            [out] int8_t arg3[3]
         );
         
         void ArrayInt16_t(
             [in] int16_t arg1[2],
-            [in,out] int16_t arg2[2][2],
-            [out] int16_t arg3[3][3],
+            [in,out] int16_t arg2[2],
+            [out] int16_t arg3[3]
         );
 
         void ArrayInt32_t(
             [in] int32_t arg1[2],
-            [in,out] int32_t arg2[2][2],
-            [out] int32_t arg3[3][3],
+            [in,out] int32_t arg2[2],
+            [out] int32_t arg3[3]
         );
 
         void ArrayInt64_t(
             [in] int64_t arg1[2],
-            [in,out] int64_t arg2[2][2],
-            [out] int64_t arg3[3][3],
+            [in,out] int64_t arg2[2],
+            [out] int64_t arg3[3]
         );
 
         void ArrayUint8_t(
             [in] uint8_t arg1[2],
-            [in,out] uint8_t arg2[2][2],
-            [out] uint8_t arg3[3][3],
+            [in,out] uint8_t arg2[2],
+            [out] uint8_t arg3[3]
         );
         
         void ArrayUint16_t(
             [in] uint16_t arg1[2],
-            [in,out] uint16_t arg2[2][2],
-            [out] uint16_t arg3[3][3],
+            [in,out] uint16_t arg2[2],
+            [out] uint16_t arg3[3]
         );
 
         void ArrayUint32_t(
             [in] uint32_t arg1[2],
-            [in,out] uint32_t arg2[2][2],
-            [out] uint32_t arg3[3][3],
+            [in,out] uint32_t arg2[2],
+            [out] uint32_t arg3[3]
         );
 
         void ArrayUint64_t(
             [in] uint64_t arg1[2],
-            [in,out] uint64_t arg2[2][2],
-            [out] uint64_t arg3[3][3]
+            [in,out] uint64_t arg2[2],
+            [out] uint64_t arg3[3]
         );
     };     
 };

--- a/tests/UnitTests/TestFiles/EnumTest.edl
+++ b/tests/UnitTests/TestFiles/EnumTest.edl
@@ -32,8 +32,8 @@ enclave
             // Use anonymous enum value for array size for this
             // parameter.
             [in] Color arg2[Nine],
-            [in,out] Color arg3[5][5],
-            [out] Color arg4[1][1][1],
+            [in, out] Color arg3[5],
+            [out] Color arg4[1],
 
             // count = 1
             [in] Color* arg5,
@@ -41,24 +41,24 @@ enclave
             [out] Color* arg7,
 
             // count attribute           
-            [in, count=Ten] Color* arg8,
-            [in,out, count=Ten] Color* arg9,
-            [out, count=Ten] Color* arg10,
+            [in] Color* arg8,
+            [in, out] Color* arg9,
+            [out] Color* arg10,
 
             // size attribute
-            [in, size=8] Color* arg11,
-            [in,out, size=8] Color* arg12,
-            [out, size=8] Color* arg13,
+            [in] Color* arg11,
+            [in, out] Color* arg12,
+            [out] Color* arg13,
 
             // count parameter
-            [in, count=arg20] Color* arg14,
-            [in,out, count=arg20] Color* arg15,
-            [out, count=arg20] Color* arg16,
+            [in] Color* arg14,
+            [in, out] Color* arg15,
+            [out] Color* arg16,
 
             // size parameter
-            [in, size=arg21] Color* arg17,
-            [in,out, size=arg21] Color* arg18,
-            [out, size=arg21] Color* arg19,
+            [in] Color* arg17,
+            [in, out] Color* arg18,
+            [out] Color* arg19,
 
             size_t arg20,
             size_t arg21
@@ -71,33 +71,33 @@ enclave
             Color arg1,
 
             [in] Color arg2[5],
-            [in,out] Color arg3[5][5],
-            [out] Color arg4[1][1][1],
+            [in,out] Color arg3[5],
+            [out] Color arg4[1],
 
             // count = 1
             [in] Color* arg5,
-            [in,out] Color* arg6,
+            [in, out] Color* arg6,
             [out] Color* arg7,
 
             // count attribute           
-            [in, count=5] Color* arg8,
-            [in,out, count=5] Color* arg9,
-            [out, count=5] Color* arg10,
+            [in] Color* arg8,
+            [in, out] Color* arg9,
+            [out] Color* arg10,
 
             // size attribute
-            [in, size=8] Color* arg11,
-            [in,out, size=8] Color* arg12,
-            [out, size=8] Color* arg13,
+            [in] Color* arg11,
+            [in, out] Color* arg12,
+            [out] Color* arg13,
 
             // count parameter
-            [in, count=arg20] Color* arg14,
-            [in,out, count=arg20] Color* arg15,
-            [out, count=arg20] Color* arg16,
+            [in] Color* arg14,
+            [in, out] Color* arg15,
+            [out] Color* arg16,
 
             // size parameter
-            [in, size=arg21] Color* arg17,
-            [in,out, size=arg21] Color* arg18,
-            [out, size=arg21] Color* arg19,
+            [in] Color* arg17,
+            [in, out] Color* arg18,
+            [out] Color* arg19,
 
             size_t arg20,
             size_t arg21

--- a/tests/UnitTests/TestFiles/StructTest.edl
+++ b/tests/UnitTests/TestFiles/StructTest.edl
@@ -20,12 +20,6 @@ enclave
         int32_t y;
     };
 
-    struct MyStruct_node
-    {
-        char data;
-        MyStruct_node *next;
-    };
-
     trusted 
     {
         MyStruct1 TrustedGetStruct1 (
@@ -33,28 +27,28 @@ enclave
 
             // Array of structs
             [in] MyStruct1 arg2[5],
-            [in, out] MyStruct1 arg3[5][5],
-            [out] MyStruct1 arg4[1][1][1],
+            [in, out] MyStruct1 arg3[5],
+            [out] MyStruct1 arg4[1],
             
             [in] MyStruct1* arg5,
             [in, out] MyStruct1* arg6,
             [out] MyStruct1* arg7,
 
-            [in, count=5] MyStruct1* arg8,
-            [in, out, count=5] MyStruct1* arg9,
-            [out, count=5] MyStruct1* arg10,
+            [in] MyStruct1* arg8,
+            [in, out] MyStruct1* arg9,
+            [out] MyStruct1* arg10,
 
-            [in, size=40] MyStruct1* arg11,
-            [in, out, size=40] MyStruct1* arg12,
-            [out, size=40] MyStruct1* arg13,
+            [in] MyStruct1* arg11,
+            [in, out] MyStruct1* arg12,
+            [out] MyStruct1* arg13,
             
-            [in, count=arg20] MyStruct1* arg14,
-            [in, out, count=arg20] MyStruct1* arg15,
-            [out, count=arg20] MyStruct1* arg16,            
+            [in] MyStruct1* arg14,
+            [in, out] MyStruct1* arg15,
+            [out] MyStruct1* arg16,            
 
-            [in, size=arg21] MyStruct1* arg17,
-            [in, out, size=arg21] MyStruct1* arg18,
-            [out, size=arg21] MyStruct1* arg19,               
+            [in] MyStruct1* arg17,
+            [in, out] MyStruct1* arg18,
+            [out] MyStruct1* arg19,               
 
             size_t arg20,
             size_t arg21
@@ -68,28 +62,28 @@ enclave
 
             // Array of structs
             [in] MyStruct1 arg2[5],
-            [in, out] MyStruct1 arg3[5][5],
-            [out] MyStruct1 arg4[1][1][1],
+            [in, out] MyStruct1 arg3[5],
+            [out] MyStruct1 arg4[1],
             
             [in] MyStruct1* arg5,
             [in, out] MyStruct1* arg6,
             [out] MyStruct1* arg7,
 
-            [in, count=5] MyStruct1* arg8,
-            [in, out, count=5] MyStruct1* arg9,
-            [out, count=5] MyStruct1* arg10,
+            [in] MyStruct1* arg8,
+            [in, out] MyStruct1* arg9,
+            [out] MyStruct1* arg10,
 
-            [in, size=40] MyStruct1* arg11,
-            [in, out, size=40] MyStruct1* arg12,
-            [out, size=40] MyStruct1* arg13,
+            [in] MyStruct1* arg11,
+            [in, out] MyStruct1* arg12,
+            [out] MyStruct1* arg13,
             
-            [in, count=arg20] MyStruct1* arg14,
-            [in, out, count=arg20] MyStruct1* arg15,
-            [out, count=arg20] MyStruct1* arg16,            
+            [in] MyStruct1* arg14,
+            [in, out] MyStruct1* arg15,
+            [out] MyStruct1* arg16,            
 
-            [in, size=arg21] MyStruct1* arg17,
-            [in, out, size=arg21] MyStruct1* arg18,
-            [out, size=arg21] MyStruct1* arg19,               
+            [in] MyStruct1* arg17,
+            [in, out] MyStruct1* arg18,
+            [out] MyStruct1* arg19,               
 
             size_t arg20,
             size_t arg21

--- a/tests/UnitTests/ToolingExecutableTests/CmdlineArgumentsParserTests.cpp
+++ b/tests/UnitTests/ToolingExecutableTests/CmdlineArgumentsParserTests.cpp
@@ -9,7 +9,7 @@
 using namespace CmdlineParsingHelpers;
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
-const std::string c_edl_path_valid_input = "test.edl";
+const std::string c_edl_path_valid_input = "BasicTypesTest.edl";
 
 namespace VbsEnclaveToolingTests
 {
@@ -27,20 +27,6 @@ namespace VbsEnclaveToolingTests
         std::string m_error_handling_arg = "--ErrorHandling";
         std::string m_error_handling_valid_input[2] = { "ErrorCode", "Exception" };
     public:
-        
-
-        TEST_CLASS_INITIALIZE(Setup)
-        {
-            // create test file.
-            std::ofstream file(c_edl_path_valid_input);
-            file.close();
-        }
-
-        TEST_CLASS_CLEANUP(TearDown)
-        {
-            // delete test file.
-            std::filesystem::remove(c_edl_path_valid_input);
-        }
 
         // Test valid parsing for known arguments
         TEST_METHOD(TestValidArguments)

--- a/tests/UnitTests/ToolingExecutableTests/EdlParserTestHelpers.h
+++ b/tests/UnitTests/ToolingExecutableTests/EdlParserTestHelpers.h
@@ -22,19 +22,19 @@ namespace VbsEnclaveToolingTests
     {
         // ArrayTest.edl expected function signatures where key is function name and value is its signature
 
-        {"ArrayChar", "ArrayChar(char[2],char[2][2],char[3][3])"},
-        {"ArrayWchar_t", "ArrayWchar_t(wchar_t[2],wchar_t[2][2],wchar_t[3][3])"},
-        { "ArrayFloat", "ArrayFloat(float[2],float[2][2],float[3][3])" },
-        { "ArrayDouble", "ArrayDouble(double[2],double[2][2],double[3][3])" },
-        { "ArraySize_t", "ArraySize_t(size_t[2],size_t[2][2],size_t[3][3])" },
-        { "ArrayInt8_t", "ArrayInt8_t(int8_t[2],int8_t[2][2],int8_t[3][3])" },
-        { "ArrayInt16_t", "ArrayInt16_t(int16_t[2],int16_t[2][2],int16_t[3][3])" },
-        { "ArrayInt32_t", "ArrayInt32_t(int32_t[2],int32_t[2][2],int32_t[3][3])" },
-        { "ArrayInt64_t", "ArrayInt64_t(int64_t[2],int64_t[2][2],int64_t[3][3])" },
-        { "ArrayUint8_t", "ArrayUint8_t(uint8_t[2],uint8_t[2][2],uint8_t[3][3])" },
-        { "ArrayUint16_t", "ArrayUint16_t(uint16_t[2],uint16_t[2][2],uint16_t[3][3])" },
-        { "ArrayUint32_t", "ArrayUint32_t(uint32_t[2],uint32_t[2][2],uint32_t[3][3])" },
-        { "ArrayUint64_t", "ArrayUint64_t(uint64_t[2],uint64_t[2][2],uint64_t[3][3])" },
+        {"ArrayChar", "ArrayChar(char[2],char[2],char[3])"},
+        {"ArrayWchar_t", "ArrayWchar_t(wchar_t[2],wchar_t[2],wchar_t[3])"},
+        { "ArrayFloat", "ArrayFloat(float[2],float[2],float[3])" },
+        { "ArrayDouble", "ArrayDouble(double[2],double[2],double[3])" },
+        { "ArraySize_t", "ArraySize_t(size_t[2],size_t[2],size_t[3])" },
+        { "ArrayInt8_t", "ArrayInt8_t(int8_t[2],int8_t[2],int8_t[3])" },
+        { "ArrayInt16_t", "ArrayInt16_t(int16_t[2],int16_t[2],int16_t[3])" },
+        { "ArrayInt32_t", "ArrayInt32_t(int32_t[2],int32_t[2],int32_t[3])" },
+        { "ArrayInt64_t", "ArrayInt64_t(int64_t[2],int64_t[2],int64_t[3])" },
+        { "ArrayUint8_t", "ArrayUint8_t(uint8_t[2],uint8_t[2],uint8_t[3])" },
+        { "ArrayUint16_t", "ArrayUint16_t(uint16_t[2],uint16_t[2],uint16_t[3])" },
+        { "ArrayUint32_t", "ArrayUint32_t(uint32_t[2],uint32_t[2],uint32_t[3])" },
+        { "ArrayUint64_t", "ArrayUint64_t(uint64_t[2],uint64_t[2],uint64_t[3])" },
 
         // BasicTypesTest.edl function signatures where key is function name and value is its signature
   
@@ -57,13 +57,13 @@ namespace VbsEnclaveToolingTests
 
         // EnumTest.edl function signatures where key is function name and value is its signature
 
-        {"TrustedGetColor", "TrustedGetColor(Color,Color[Nine],Color[5][5],Color[1][1][1],Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,size_t,size_t)"},
-        {"UntrustedGetColor", "UntrustedGetColor(Color,Color[5],Color[5][5],Color[1][1][1],Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,size_t,size_t)"},
+        {"TrustedGetColor", "TrustedGetColor(Color,Color[Nine],Color[5],Color[1],Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,size_t,size_t)"},
+        {"UntrustedGetColor", "UntrustedGetColor(Color,Color[5],Color[5],Color[1],Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,size_t,size_t)"},
 
         // StructTest.edl function signatures where key is function name and value is its signature
 
-        {"TrustedGetStruct1", "TrustedGetStruct1(MyStruct1,MyStruct1[5],MyStruct1[5][5],MyStruct1[1][1][1],MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,size_t,size_t)"},
-        {"UntrustedGetStruct1", "UntrustedGetStruct1(MyStruct1,MyStruct1[5],MyStruct1[5][5],MyStruct1[1][1][1],MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,size_t,size_t)"},
+        {"TrustedGetStruct1", "TrustedGetStruct1(MyStruct1,MyStruct1[5],MyStruct1[5],MyStruct1[1],MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,size_t,size_t)"},
+        {"UntrustedGetStruct1", "UntrustedGetStruct1(MyStruct1,MyStruct1[5],MyStruct1[5],MyStruct1[1],MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,size_t,size_t)"},
     };
 
     static inline std::wstring ConvertExceptionMessageToWstring(const std::exception& exception)


### PR DESCRIPTION
When working on the codegen I made some slight changes to the edl parser which resulted in some of the unit tests failing. This PR aims to bring the unit tests back into a passing state.

### What changed
- We only support one dimensional arrays now so I removed the extra dimensions from arrays in the test .edl files
- Within a .edl file, we expect pointers inside structs to point to other structs that have already been defined inside the .edl file. Due to this, inside the `StructTest.edl` file I removed the `MyStruct_node` struct that contained a pointer to a `MyStruct_node`.  Although I have to remove this from the test, we can update the parser to allow for this behavior in the future if needed.
- The cmdline parser test currently `creates` and `removes` a .edl file before performing its tests. I realized that we already have .edl test files that we can use instead, so we're now using the static `BasicTypesTest.edl` file we have in the repo instead of creating a `test.edl` file at runtime when the test runs.
- removed the `size` and `count` attributes from the test .edl files as they are not used by our parser.

### How was it tested.
- Confirmed tests now all passing. (Note: had to fix build error, using https://github.com/microsoft/VbsEnclaveTooling/pull/97 first)
![image](https://github.com/user-attachments/assets/0fb53fb5-fd03-467d-ba83-7e06890bd5bc)

### TODO
- Once this issue https://github.com/microsoft/VbsEnclaveTooling/issues/96 is complete, this shouldn't happen, since the PR build will run the tests.
- Also need to add unit tests for parsing vector<T> in a future PR, I figured it would be best to do that separately.