### PR TITLE
Reduce codegen by adding templates for dev type -> flatbuffer and flatbuffer -> dev type conversion functions

### DIFF
--- a/src/ToolingSharedLibrary/Includes/CodeGeneration/CodeGeneration.h
+++ b/src/ToolingSharedLibrary/Includes/CodeGeneration/CodeGeneration.h
@@ -44,7 +44,7 @@ namespace CodeGeneration
         struct FunctionParametersInfo
         {
             // Used to moving parameters through trust boundary
-            std::ostringstream m_in_and_inout_param_names {};
+            std::ostringstream m_param_to_convert_names {};
             std::ostringstream m_copy_values_from_out_struct_to_original_args {};
             std::ostringstream m_params_to_forward_to_dev_impl {};
 

--- a/src/ToolingSharedLibrary/Includes/CodeGeneration/CodeGeneration.h
+++ b/src/ToolingSharedLibrary/Includes/CodeGeneration/CodeGeneration.h
@@ -64,13 +64,11 @@ namespace CodeGeneration
 
         std::string BuildStructField(const Declaration& declaration);
 
-        std::string BuildStructDefinition(const DeveloperType& developer_types);
-
-        std::string BuildStructDefinitionForABIDeveloperType(
+        std::string BuildStructDefinition(
             std::string_view struct_name,
             const std::vector<Declaration>& fields);
 
-        std::string BuildStructDefinitionForNonABIDeveloperType(
+        std::string BuildStructMetaData(
             std::string_view struct_name,
             const std::vector<Declaration>& fields);
 

--- a/src/ToolingSharedLibrary/Includes/CodeGeneration/Contants.h
+++ b/src/ToolingSharedLibrary/Includes/CodeGeneration/Contants.h
@@ -494,7 +494,7 @@ R"(
 R"(             using ReturnParamsT = FlatbuffersDevTypes::{}T;)";
 
     static inline constexpr std::string_view c_in_and_inout_parameter_conversion_statement =
-"            in_flatbufferT.m_{} = ConvertToFlatbuffer<decltype({}), decltype(in_flatbufferT.m_{})>({});\n";
+"            in_flatbufferT.m_{} = ConvertType<decltype(in_flatbufferT.m_{})>({});\n";
 
     static inline constexpr std::string_view c_pack_params_to_flatbuffer_call =
 R"(// Package in and in/out parameters into struct and convert it to a flatbuffer type.
@@ -511,7 +511,7 @@ R"({} dev_type_params{{}};
 )";
 
     static inline constexpr std::string_view c_conversion_to_dev_type_statement =
-R"(            ConvertStruct<ConversionType::ToDevType, decltype(in_flatbuffer_params), decltype(dev_type_params)>(in_flatbuffer_params, dev_type_params);
+R"(auto dev_type_params = ConvertStruct<{}>(in_flatbuffer_params);
 )";
 
     static inline constexpr std::string_view c_abi_func_return_value =
@@ -523,16 +523,14 @@ R"({}({});
 {})";
 
     static inline constexpr std::string_view c_setup_return_params_struct = R"(
-            FlatbuffersDevTypes::{}T flatbuffer_out_param{{}};
-            ConvertStruct<ConversionType::ToFlatbuffer, decltype(dev_type_params), decltype(flatbuffer_out_param)>(dev_type_params, flatbuffer_out_param);
+            auto flatbuffer_out_param = ConvertStruct<decltype(in_flatbuffer_params)>(dev_type_params);
             flatbuffer_out_params_builder = PackFlatbuffer(flatbuffer_out_param);)";
 
     static inline constexpr std::string_view c_setup_no_return_params_struct = R"(
             flatbuffer_out_params_builder = PackFlatbuffer<FlatbuffersDevTypes::{}T>({{}});)";
 
     static inline constexpr std::string_view c_setup_return_params_back_to_developer = R"(
-            {} return_params{{}};
-            ConvertStruct<ConversionType::ToDevType, decltype(function_result), decltype(return_params)>(function_result, return_params);
+            auto return_params = ConvertStruct<{}>(function_result);
             {}
 )";
 
@@ -556,7 +554,7 @@ R"(        using ReturnParamsT = FlatbuffersDevTypes::{}T;)";
     static inline constexpr std::string_view c_struct_meta_data_outline = 
 R"(
 template <>
-struct StructMetaData<{}>
+struct StructMetadata<{}>
 {{
     static constexpr auto members = std::make_tuple({});
 }};

--- a/src/ToolingSharedLibrary/Includes/CodeGeneration/Contants.h
+++ b/src/ToolingSharedLibrary/Includes/CodeGeneration/Contants.h
@@ -71,6 +71,8 @@ namespace {}
 {{
     namespace VTL0_Stubs
     {{
+        using namespace VbsEnclaveABI::Shared::Converters;
+
         {}
     }}
 }}
@@ -220,11 +222,15 @@ namespace {}
 
     namespace VTL0_Callbacks
     {{
+        using namespace VbsEnclaveABI::Shared::Converters;
+
         {}
     }}
 
     namespace AbiDefinitions
     {{
+        using namespace VbsEnclaveABI::Shared::Converters;
+
         {}
     }}
 }}
@@ -241,7 +247,6 @@ namespace {}
 #include \"vbsenclave_flatbuffer_support_generated.h\"\n\
 #include <VbsEnclaveABI\\Shared\\ConversionHelpers.h>\n\
 \n\
-using namespace VbsEnclaveABI::Shared::Converters;\n\
 ";
 
     static inline constexpr std::string_view c_developer_types_namespace = R"(
@@ -251,7 +256,10 @@ namespace DeveloperTypes
 }}
 
 // Struct metadata
+namespace VbsEnclaveABI::Shared::Converters
+{{
 {}
+}}
 )";
 
     static inline constexpr std::string_view c_enclave_def_file_content = R"(
@@ -493,7 +501,7 @@ R"(
     static inline constexpr std::string_view c_parameter_struct_using_statement =
 R"(             using ReturnParamsT = FlatbuffersDevTypes::{}T;)";
 
-    static inline constexpr std::string_view c_in_and_inout_parameter_conversion_statement =
+    static inline constexpr std::string_view c_parameter_conversion_statement =
 "            in_flatbufferT.m_{} = ConvertType<decltype(in_flatbufferT.m_{})>({});\n";
 
     static inline constexpr std::string_view c_pack_params_to_flatbuffer_call =

--- a/src/ToolingSharedLibrary/Includes/CodeGeneration/Contants.h
+++ b/src/ToolingSharedLibrary/Includes/CodeGeneration/Contants.h
@@ -239,7 +239,9 @@ namespace {}
 #include <VbsEnclaveABI\\Shared\\VbsEnclaveAbiBase.h>\n\
 #undef max // prevent windows max macro from conflicting with flatbuffers macro\n\
 #include \"vbsenclave_flatbuffer_support_generated.h\"\n\
+#include <VbsEnclaveABI\\Shared\\ConversionHelpers.h>\n\
 \n\
+using namespace VbsEnclaveABI::Shared::Converters;\n\
 ";
 
     static inline constexpr std::string_view c_developer_types_namespace = R"(
@@ -247,6 +249,9 @@ namespace DeveloperTypes
 {{
 {}
 }}
+
+// Struct metadata
+{}
 )";
 
     static inline constexpr std::string_view c_enclave_def_file_content = R"(
@@ -453,83 +458,108 @@ R"(     {}_Generated_Stub
 
     static inline constexpr std::string_view c_return_param_for_out_param_ptr = 
 R"(     
-            if (return_params->m_{})
+            if (return_params.m_{})
             {{
-                {} = std::move(return_params->m_{});
+                {} = std::move(return_params.m_{});
             }}
 )";
 
     static inline constexpr std::string_view c_return_param_for_inout_param_ptr =
 R"(     
-            if ({} && return_params->m_{})
+            if ({} && return_params.m_{})
             {{
-                *{} = *return_params->m_{};
+                *{} = *return_params.m_{};
             }}
 )";
 
     static inline constexpr std::string_view c_return_param_for_inout_param_ptr_with_move =
 R"(     
-            if ({} && return_params->m_{})
+            if ({} && return_params.m_{})
             {{
-                *{} = std::move(*return_params->m_{}); 
+                *{} = std::move(*return_params.m_{}); 
             }}
 )";
 
     static inline constexpr std::string_view c_return_param_for_inout_param_with_move =
 R"(     
-            {} = std::move(return_params->m_{});
+            {} = std::move(return_params.m_{});
 )";
 
 static inline constexpr std::string_view c_return_param_for_basic_type =
 R"(     
-            {} = return_params->m_{};
+            {} = return_params.m_{};
 )";
     
     static inline constexpr std::string_view c_parameter_struct_using_statement =
 R"(             using ReturnParamsT = FlatbuffersDevTypes::{}T;)";
 
+    static inline constexpr std::string_view c_in_and_inout_parameter_conversion_statement =
+"            in_flatbufferT.m_{} = ConvertToFlatbuffer<decltype({}), decltype(in_flatbufferT.m_{})>({});\n";
+
     static inline constexpr std::string_view c_pack_params_to_flatbuffer_call =
 R"(// Package in and in/out parameters into struct and convert it to a flatbuffer type.
-            auto in_flatbufferT = {}::ToFlatBuffer({});
+            FlatbuffersDevTypes::{}T in_flatbufferT {{}};
+{}
             using ParamsT = decltype(in_flatbufferT);
-            auto flatbuffer_builder = PackFlatbuffer(*in_flatbufferT);
+            auto flatbuffer_builder = PackFlatbuffer(in_flatbufferT);
     )";
 
     static inline constexpr std::string_view c_abi_impl_function_parameters = "(_In_ FlatbuffersDevTypes::{}_argsT& in_flatbuffer_params, _In_ flatbuffers::FlatBufferBuilder& flatbuffer_out_params_builder)";
 
+    static inline constexpr std::string_view c_instantiate_dev_type =
+R"({} dev_type_params{{}};
+)";
+
+    static inline constexpr std::string_view c_conversion_to_dev_type_statement =
+R"(            ConvertStruct<ConversionType::ToDevType, decltype(in_flatbuffer_params), decltype(dev_type_params)>(in_flatbuffer_params, dev_type_params);
+)";
+
     static inline constexpr std::string_view c_abi_func_return_value =
-R"(auto dev_type_params = {}::ToDevType(in_flatbuffer_params);
-            dev_type_params->m__return_value_ = {}({});
+R"(            dev_type_params.m__return_value_ = {}({});
 {})";
 
     static inline constexpr std::string_view c_abi_func_return_when_void =
-R"(auto dev_type_params = {}::ToDevType(in_flatbuffer_params);
-            {}({});
+R"({}({});
 {})";
 
     static inline constexpr std::string_view c_setup_return_params_struct = R"(
-            auto flatbuffer_out_param = {}::ToFlatBuffer(*dev_type_params);
-            flatbuffer_out_params_builder = PackFlatbuffer(*flatbuffer_out_param);)";
+            FlatbuffersDevTypes::{}T flatbuffer_out_param{{}};
+            ConvertStruct<ConversionType::ToFlatbuffer, decltype(dev_type_params), decltype(flatbuffer_out_param)>(dev_type_params, flatbuffer_out_param);
+            flatbuffer_out_params_builder = PackFlatbuffer(flatbuffer_out_param);)";
 
     static inline constexpr std::string_view c_setup_no_return_params_struct = R"(
             flatbuffer_out_params_builder = PackFlatbuffer<FlatbuffersDevTypes::{}T>({{}});)";
 
     static inline constexpr std::string_view c_setup_return_params_back_to_developer = R"(
-            auto return_params = {}::ToDevType(function_result);
+            {} return_params{{}};
+            ConvertStruct<ConversionType::ToDevType, decltype(function_result), decltype(return_params)>(function_result, return_params);
             {}
 )";
 
     static inline constexpr std::string_view c_return_value_back_to_initial_caller_with_move =
 R"(             
-            return std::move(return_params->m__return_value_);)";
+            return std::move(return_params.m__return_value_);)";
 
     static inline constexpr std::string_view c_return_value_back_to_initial_caller_no_move =
 R"(             
-            return return_params->m__return_value_;)";
+            return return_params.m__return_value_;)";
 
     static inline constexpr std::string_view c_parameter_return_struct_using_statement =
 R"(        using ReturnParamsT = FlatbuffersDevTypes::{}T;)";
 
     static inline constexpr std::string_view c_function_args_struct = "{}_args";
+
+    static inline constexpr std::string_view c_struct_metadata_field_ptr = "&DeveloperTypes::{}::{}{}";
+
+    static inline constexpr std::string_view c_flatbuffer_field_ptr = "&FlatbuffersDevTypes::{}T::{}{}";
+
+    static inline constexpr std::string_view c_struct_meta_data_outline = 
+R"(
+template <>
+struct StructMetaData<{}>
+{{
+    static constexpr auto members = std::make_tuple({});
+}};
+)";
 }
 

--- a/src/ToolingSharedLibrary/Includes/CodeGeneration/Flatbuffers/Contants.h
+++ b/src/ToolingSharedLibrary/Includes/CodeGeneration/Flatbuffers/Contants.h
@@ -44,30 +44,6 @@ table {} {{
 }}
 )";
 
-    static inline constexpr std::string_view c_flatbuffers_helper_functions =
-R"(
-inline std::wstring ConvertToStdWString(const FlatbuffersDevTypes::WStringT& wstr)
-{
-    return std::wstring(wstr.wchars.begin(), wstr.wchars.end());
-}
-inline std::wstring ConvertToStdWString(const std::unique_ptr<FlatbuffersDevTypes::WStringT>& wstr)
-{
-    return ConvertToStdWString(*wstr);
-}
-inline std::unique_ptr<FlatbuffersDevTypes::WStringT> CreateWStringT(const std::wstring& wchars)
-{
-    auto wchart_ptr = std::make_unique<FlatbuffersDevTypes::WStringT>();
-    THROW_IF_NULL_ALLOC(wchart_ptr);
-    wchart_ptr->wchars.assign(wchars.begin(), wchars.end());
-    return wchart_ptr;
-}
-template<typename T, typename U>
-inline U ConvertEnum(T enum_1)
-{
-    return static_cast<U>(enum_1);
-}
-    )";
-
 static inline constexpr std::string_view c_flatbuffer_fbs_filename = "vbsenclave_flatbuffer_support.fbs";
 
 static inline std::string c_failed_to_compile_flatbuffer_msg = std::format("Compiling flatbuffer schema file: {}", c_flatbuffer_fbs_filename);

--- a/src/ToolingSharedLibrary/Includes/VbsEnclaveABI/Shared/ConversionHelpers.h
+++ b/src/ToolingSharedLibrary/Includes/VbsEnclaveABI/Shared/ConversionHelpers.h
@@ -164,9 +164,6 @@ namespace VbsEnclaveABI::Shared::Converters
     concept IsPtrToEnumOrArithmeticType = RawPtr<T> && (std::is_arithmetic_v<std::remove_pointer_t<T>> || std::is_enum_v<std::remove_pointer_t<T>>);
 
     template <typename T, typename U>
-    concept IsVectorAndStdArray = (Vector<T> && StdArray<U>) || (Vector<U> && StdArray<T>);
-
-    template <typename T, typename U>
     concept AreBothUniquePtrs = UniquePtr<T> && UniquePtr<U>;
 
     template <typename T, typename U>
@@ -362,7 +359,7 @@ namespace VbsEnclaveABI::Shared::Converters
         {
             return ConvertToOptional<DecayedTarget>(src);
         }
-        else if constexpr (Vector<DecayedTarget> || (StdArray<DecayedTarget>))
+        else if constexpr (Vector<DecayedTarget> || StdArray<DecayedTarget>)
         {
             using InnerSrcType = vector_or_array_inner_type_t<DecayedSrc>;
             using InnerTargetType = vector_or_array_inner_type_t<DecayedTarget>;

--- a/src/ToolingSharedLibrary/Includes/VbsEnclaveABI/Shared/ConversionHelpers.h
+++ b/src/ToolingSharedLibrary/Includes/VbsEnclaveABI/Shared/ConversionHelpers.h
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 #pragma once 
-#undef min
-#undef max
 #include <algorithm>
 #include <array>
 #include <memory>

--- a/src/ToolingSharedLibrary/Includes/VbsEnclaveABI/Shared/ConversionHelpers.h
+++ b/src/ToolingSharedLibrary/Includes/VbsEnclaveABI/Shared/ConversionHelpers.h
@@ -1,0 +1,543 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once 
+#include <VbsEnclaveABI\Shared\VbsEnclaveAbiBase.h>
+#include <string>
+#include <memory>
+#include <type_traits>
+#include <stdexcept>
+#undef min
+#undef max
+#include <algorithm>
+
+// All types and functions within this file should be usable within both the hostApp and the enclave.
+namespace VbsEnclaveABI::Shared::Converters
+{
+    enum class ConversionType : std::uint32_t
+    {
+        ToDevType,
+        ToFlatbuffer
+    };
+
+    // Base for all generated struct metadata.
+    template <typename T>
+    struct StructMetaData;
+
+    // Type traits
+    template<typename T>
+    struct is_unique_ptr : std::false_type {};
+
+    template<typename T, typename D>
+    struct is_unique_ptr<std::unique_ptr<T, D>> : std::true_type {};
+
+    template<typename T>
+    struct unique_ptr_inner_type { using type = void; };
+
+    template<typename T, typename D>
+    struct unique_ptr_inner_type<std::unique_ptr<T, D>> { using type = std::decay_t<T>; };
+
+    template<typename T>
+    using unique_ptr_inner_type_t = unique_ptr_inner_type<std::decay_t<T>>::type;
+
+    template <typename T>
+    constexpr bool is_unique_ptr_v = is_unique_ptr<std::decay_t<T>>::value;
+
+    template <typename T>
+    struct is_optional : std::false_type {};
+
+    template <typename T>
+    struct is_optional<std::optional<T>> : std::true_type {};
+
+    template <typename T>
+    struct optional_inner_type { using type = void; };
+
+    template <typename T>
+    struct optional_inner_type<std::optional<T>> { using type = std::decay_t<T>; };
+
+    template<typename T>
+    using optional_inner_type_t = optional_inner_type<std::decay_t<T>>::type;
+
+    template <typename T>
+    constexpr bool is_optional_v = is_optional<std::decay_t<T>>::value;
+
+    template <typename T>
+    struct is_vector : std::false_type {};
+
+    template <typename T, typename Alloc>
+    struct is_vector<std::vector<T, Alloc>> : std::true_type {};
+
+    template <typename T>
+    struct vector_inner_type { using type = void; };
+
+    template <typename T, typename Alloc>
+    struct vector_inner_type<std::vector<T, Alloc>> { using type = std::decay_t<T>; };
+
+    template<typename T>
+    using vector_inner_type_t = vector_inner_type<std::decay_t<T>>::type;
+
+    template <typename T>
+    constexpr bool is_vector_v = is_vector<T>::value;
+
+    template <typename T>
+    struct is_std_array : std::false_type {};
+
+    template <typename T, std::size_t N>
+    struct is_std_array<std::array<T, N>> : std::true_type {};
+
+    template <typename T>
+    struct std_array_inner_type { using type = void; };
+
+    template <typename T, std::size_t N>
+    struct std_array_inner_type<std::array<T, N>> { using type = std::decay_t<T>; };
+
+    template<typename T>
+    using std_array_inner_type_t = std_array_inner_type<std::decay_t<T>>::type;
+
+    template <typename T>
+    struct is_container_type : std::false_type {};
+
+    template <>
+    struct is_container_type<std::string> : std::true_type {};
+
+    template <>
+    struct is_container_type<std::wstring> : std::true_type {};
+
+    template <typename U, typename Alloc>
+    struct is_container_type<std::vector<U, Alloc>> : std::true_type {};
+
+    template <typename U, std::size_t N>
+    struct is_container_type<std::array<U, N>> : std::true_type {};
+
+    template <typename T>
+    constexpr bool is_container_v = is_container_type<T>::value;
+
+    template <typename T>
+    constexpr bool is_std_array_v = is_std_array<T>::value;
+
+    template <typename T>
+    using remove_pointer_t = typename std::remove_pointer<T>::type;
+
+    template<typename T>
+    concept UniquePtr = is_unique_ptr_v<T>;
+
+    template<typename T>
+    concept Optional = is_optional_v<T>;
+
+    template<typename T>
+    concept Vector = is_vector_v<T>;
+
+    template<typename T>
+    concept StdArray = is_std_array_v<T>;
+
+    template<typename T>
+    concept Container = is_container_v<T>;
+
+    template<typename T>
+    concept RawPtr = std::is_pointer_v<T>;
+
+    template<typename T>
+    concept NonWrappedStruct =
+        std::is_class_v<std::decay_t<T>> &&    // Must be a class or struct
+        !UniquePtr<std::decay_t<T>> &&   // Must not be unique ptr
+        !Optional<std::decay_t<T>> && // Must not be optional
+        !Container<std::decay_t<T>>; // Must not be wstring, string, vector or array
+
+    template <typename T, typename U>
+    concept IsOptionalAndUniquePtr =
+        (Optional<T> && UniquePtr<U>) ||
+        (Optional<U> && UniquePtr<T>);
+
+    template <typename T, typename U>
+    concept IsUniquePtrAndNonWrappedStruct =
+        (UniquePtr<T> && NonWrappedStruct<U>) ||
+        (UniquePtr<U> && NonWrappedStruct<T>);
+
+    template <typename T, typename U>
+    concept IsRawPtrAndUniquePtr =
+        (RawPtr<T> && UniquePtr<U>) ||
+        (RawPtr<U> && UniquePtr<T>);
+
+    template <typename T>
+    concept IsRawPtrAndNonWrappedStruct = RawPtr<T> && NonWrappedStruct<remove_pointer_t<T>>;
+
+    template <typename T>
+    concept IsRawPtrAndNotNonWrappedStruct = RawPtr<T> && !NonWrappedStruct<remove_pointer_t<T>>;
+
+    template <typename T, typename U>
+    concept IsVectorAndStdArray = (Vector<T> && StdArray<U>) || (Vector<U> && StdArray<T>);
+
+    template <typename T, typename U>
+    concept AreBothUniquePtrs = UniquePtr<T> && UniquePtr<U>;
+
+    template <typename T, typename U>
+    concept AreBothArithmeticTypes = std::is_arithmetic_v<T> && std::is_arithmetic_v<U>;
+
+    template <typename T, typename U>
+    concept AreBothEnums = std::is_enum_v<T> && std::is_enum_v<U>;
+
+    template <typename T, typename U>
+    concept AreBothTheSame = std::is_same_v<T, U>;
+
+    template <typename T, typename U>
+    concept AreBothNonWrappedStructs = NonWrappedStruct<T> && NonWrappedStruct<U>;
+
+    template <typename T, typename U>
+    concept AreBothVectors = Vector<T> && Vector<U>;
+
+    // Used only for static_asserts
+    template<typename...> struct always_false : std::false_type {};
+
+    template<ConversionType ConversionT, typename Src, typename Target>
+    decltype(auto) ConvertType(const Src& src)
+    {
+        using DecayedSrc = std::decay_t<Src>;
+        using DecayedTarget = std::decay_t<Target>;
+
+        if constexpr (ConversionT == ConversionType::ToDevType)
+        {
+            return ConvertToDevType<DecayedSrc, DecayedTarget>(src);
+        }
+        else
+        {
+            return ConvertToFlatbuffer<DecayedSrc, DecayedTarget>(src);
+        }
+    }
+
+    template <
+        template<typename...> class Wrapper,
+        typename Src,
+        typename TargetInnerType,
+        typename AllocFunc, 
+        typename ConvertFunc
+    >
+    auto ConvertToWrapper(const Src& src, AllocFunc&& allocator_func, ConvertFunc&& converter_func)
+    {
+        using DecayedSrc = std::decay_t<Src>;
+
+        if constexpr (UniquePtr<DecayedSrc>)
+        {
+            if (!src)
+            {
+                return Wrapper<TargetInnerType>{};
+            }
+
+            return allocator_func(converter_func(*src));
+        }
+        else if constexpr (Optional<DecayedSrc>)
+        {
+            if (!src.has_value())
+            {
+                return Wrapper<TargetInnerType>{};
+            }
+
+            return allocator_func(converter_func(src.value()));
+        }
+        else if constexpr (RawPtr<DecayedSrc>)
+        {
+            if (!src)
+            {
+                return Wrapper<TargetInnerType>{};
+            }
+
+            return allocator_func(converter_func(*src));
+        }
+        else if constexpr (NonWrappedStruct<DecayedSrc>)
+        {
+            return allocator_func(converter_func(src));
+        }
+        else
+        {
+            static_assert(always_false<Src>::value, "Unsupported src type for ConvertToWrapper.");
+        }
+    }
+
+    template <ConversionType ConversionT, typename Src, UniquePtr Target>
+    inline std::decay_t<Target> ConvertToUniquePtr(const Src& src)
+    {
+        using TargetInnerType = unique_ptr_inner_type_t<Target>;
+        auto allocator_func = [] (auto&& value)
+        {
+            auto ptr = std::make_unique<TargetInnerType>();
+            THROW_IF_NULL_ALLOC(ptr.get());
+            *ptr = std::forward<decltype(value)>(value);
+            return ptr;
+        };
+
+        auto converter_func = [] (auto&& value)
+        {
+            using SrcInnerType = std::decay_t<decltype(value)>;
+            return ConvertType<ConversionT, SrcInnerType, TargetInnerType>(value);
+        };
+
+        return ConvertToWrapper<std::unique_ptr, Src, TargetInnerType>(src, allocator_func, converter_func);
+    }
+
+    template <ConversionType ConversionT, typename Src, Optional Target>
+    inline std::decay_t<Target> ConvertToOptional(const Src& src)
+    {
+        using TargetInnerType = optional_inner_type_t<Target>;
+        auto allocator_func = [] (auto&& value)
+        {
+            return std::make_optional<TargetInnerType>(std::forward<decltype(value)>(value));
+        };
+
+        auto converter_func = [] (auto&& value)
+        {
+            using SrcInnerType = std::decay_t<decltype(value)>;
+            return ConvertType<ConversionT, SrcInnerType, TargetInnerType>(value);
+        };
+
+        return ConvertToWrapper<std::optional, Src, TargetInnerType>(src, allocator_func, converter_func);
+    }
+
+    template<typename T>
+    inline std::wstring ConvertToStdWString(const T& wstr)
+    {
+        if constexpr (UniquePtr<T>)
+        {
+            if (!wstr)
+            {
+                return {};
+            }
+
+            return std::wstring(wstr->wchars.begin(), wstr->wchars.end());
+        }
+        else
+        {
+            return std::wstring(wstr.wchars.begin(), wstr.wchars.end());
+        }
+    }
+
+    template<typename FlatbufferType>
+    inline FlatbufferType CreateWStringT(const std::wstring& wchars)
+    {
+        using Decayed = std::decay_t<FlatbufferType>;
+        if constexpr (UniquePtr<Decayed>)
+        {
+            using InnerType = unique_ptr_inner_type_t<Decayed>;
+            auto ptr = std::make_unique<InnerType>();
+            THROW_IF_NULL_ALLOC(ptr);
+            ptr->wchars.assign(wchars.begin(), wchars.end());
+            return ptr;
+        }
+        else if constexpr (NonWrappedStruct<Decayed>)
+        {
+            Decayed wcharT {};
+            wcharT.wchars.assign(wchars.begin(), wchars.end());
+            return wcharT;
+        }
+        else
+        {
+            static_assert(always_false<FlatbufferType>::value, "CreateWStringT: Unsupported FlatbufferType (must be unique_ptr or struct)");
+        }
+    }
+
+    template <typename SrcContainer, typename TargetContainer, typename ConvertFunc>
+    TargetContainer TransformContainer(const SrcContainer& src_container, ConvertFunc&& conversion_func)
+    {
+        TargetContainer target_container;
+        target_container.reserve(src_container.size());
+        for (const auto& value : src_container)
+        {
+            target_container.emplace_back(conversion_func(value));
+        }
+
+        return target_container;
+    }
+
+    template <typename SrcContainer, typename ArrayContainer, typename ConvertFunc>
+    ArrayContainer TransformToStdArray(const SrcContainer& src_container, ConvertFunc&& conversion_func)
+    {
+        ArrayContainer array_container {};
+        size_t N = std::min(array_container.size(), src_container.size());
+        for (size_t i = 0; i < N; ++i)
+        {
+            array_container[i] = conversion_func(src_container[i]);
+        }
+
+        return array_container;
+    }
+
+    template <typename FlatbufferType, typename DevType>
+    inline std::decay_t<DevType> ConvertToDevType(const FlatbufferType& flatbuffer_type)
+    {
+        using DecayedDev = std::decay_t<DevType>;
+        using DecayedFlatBuffer = std::decay_t<FlatbufferType>;
+
+        if constexpr (AreBothTheSame<DecayedFlatBuffer, DecayedDev>)
+        {
+            return flatbuffer_type;
+        }
+        else if constexpr (AreBothArithmeticTypes<DecayedFlatBuffer, DecayedDev>)
+        {
+            return static_cast<DecayedDev>(flatbuffer_type);
+        }
+        else if constexpr (AreBothNonWrappedStructs<DecayedFlatBuffer, DecayedDev>)
+        {
+            DecayedDev dev_type {};
+            ConvertStruct<ConversionType::ToDevType, DecayedFlatBuffer, DecayedDev>(flatbuffer_type, dev_type);
+            return dev_type;
+        }
+        else if constexpr (AreBothEnums<DecayedFlatBuffer, DecayedDev>)
+        {
+            return static_cast<DecayedDev>(flatbuffer_type);
+        }
+        else if constexpr (AreBothTheSame<DecayedDev, std::wstring>)
+        {
+            return ConvertToStdWString(flatbuffer_type);
+        }
+        else if constexpr (AreBothUniquePtrs<DecayedFlatBuffer, DecayedDev>)
+        {
+            return ConvertToUniquePtr<ConversionType::ToDevType, DecayedFlatBuffer, DecayedDev>(flatbuffer_type);
+        }
+        else if constexpr (IsOptionalAndUniquePtr<DecayedFlatBuffer, DecayedDev>)
+        {
+            return ConvertToUniquePtr<ConversionType::ToDevType, DecayedFlatBuffer, DecayedDev>(flatbuffer_type);
+        }
+        else if constexpr (IsUniquePtrAndNonWrappedStruct<DecayedFlatBuffer, DecayedDev>)
+        {
+            if (!flatbuffer_type)
+            {
+                return {};
+            }
+
+            using InnerFlatbufferType = unique_ptr_inner_type_t<DecayedFlatBuffer>;
+            return ConvertToDevType<InnerFlatbufferType, DecayedDev>(*flatbuffer_type);
+        }
+        else if constexpr (AreBothVectors<DecayedFlatBuffer, DecayedDev>)
+        {
+            using InnerDevType = vector_inner_type_t<DecayedDev>;
+            using InnerFlatbufferType = vector_inner_type_t<DecayedFlatBuffer>;
+
+            return TransformContainer<DecayedFlatBuffer, DecayedDev>(flatbuffer_type, [] (const InnerFlatbufferType& value)
+            {
+                return ConvertToDevType<InnerFlatbufferType, InnerDevType>(value);
+            });
+        }
+        else if constexpr (IsVectorAndStdArray<DecayedFlatBuffer, DecayedDev>)
+        {
+            using InnerDevType = std_array_inner_type_t<DecayedDev>;
+            using InnerFlatbufferType = vector_inner_type_t<DecayedFlatBuffer>;
+
+            return TransformToStdArray<DecayedFlatBuffer, DecayedDev>(flatbuffer_type, [] (const InnerFlatbufferType& value)
+            {
+                return ConvertToDevType<InnerFlatbufferType, InnerDevType>(value);
+            });
+        }
+        else
+        {
+            static_assert(always_false<FlatbufferType, DevType>::value,
+                "Flatbuffer type to Dev type conversion not found in function: " __FUNCSIG__);
+        }
+    }
+
+    template <typename DevType, typename FlatbufferType>
+    inline std::decay_t<FlatbufferType> ConvertToFlatbuffer(const DevType& dev_type)
+    {
+        using DecayedDev = std::decay_t<DevType>;
+        using DecayedFlatBuffer = std::decay_t<FlatbufferType>;
+
+        if constexpr (AreBothTheSame<DecayedDev, DecayedFlatBuffer>)
+        {
+            return dev_type;
+        }
+        else if constexpr (AreBothArithmeticTypes<DecayedDev, DecayedFlatBuffer>)
+        {
+            return static_cast<DecayedFlatBuffer>(dev_type);
+        }
+        else if constexpr (AreBothNonWrappedStructs<DecayedDev, DecayedFlatBuffer>)
+        {
+            DecayedFlatBuffer ret {};
+            ConvertStruct<ConversionType::ToFlatbuffer, DecayedDev, DecayedFlatBuffer>(dev_type, ret);
+            return ret;
+        }
+        else if constexpr (AreBothEnums<DecayedDev, DecayedFlatBuffer>)
+        {
+            return static_cast<DecayedFlatBuffer>(dev_type);
+        }
+        else if constexpr (AreBothTheSame<DecayedDev, std::wstring>)
+        {
+            return CreateWStringT<DecayedFlatBuffer>(dev_type);
+        }
+        else if constexpr (AreBothUniquePtrs<DecayedDev, DecayedFlatBuffer>)
+        {
+            return ConvertToUniquePtr<ConversionType::ToFlatbuffer, DecayedDev, DecayedFlatBuffer>(dev_type);
+        }
+        else if constexpr (IsRawPtrAndUniquePtr<DecayedDev, DecayedFlatBuffer>)
+        {
+            return ConvertToUniquePtr<ConversionType::ToFlatbuffer, DecayedDev, DecayedFlatBuffer>(dev_type);
+        }
+        else if constexpr (IsRawPtrAndNonWrappedStruct<DecayedDev>)
+        {
+            return ConvertToUniquePtr<ConversionType::ToFlatbuffer, DecayedDev, DecayedFlatBuffer>(dev_type);
+        }
+        else if constexpr (IsRawPtrAndNotNonWrappedStruct<DecayedDev>)
+        {
+            return ConvertToOptional<ConversionType::ToFlatbuffer, DecayedDev, DecayedFlatBuffer>(dev_type);
+        }
+        else if constexpr (IsOptionalAndUniquePtr<DecayedDev, DecayedFlatBuffer>)
+        {
+            return ConvertToOptional<ConversionType::ToFlatbuffer, DecayedDev, DecayedFlatBuffer>(dev_type);
+        }
+        else if constexpr (IsUniquePtrAndNonWrappedStruct<DecayedDev, DecayedFlatBuffer>)
+        {
+            return ConvertToUniquePtr<ConversionType::ToFlatbuffer, DecayedDev, DecayedFlatBuffer>(dev_type);
+        }
+        else if constexpr (AreBothVectors<DecayedDev, DecayedFlatBuffer>)
+        {
+            using InnerDevType = vector_inner_type_t<DecayedDev>;
+            using InnerFlatbufferType = vector_inner_type_t<DecayedFlatBuffer>;
+            
+            return TransformContainer<DecayedDev, DecayedFlatBuffer>(dev_type, [] (const InnerDevType& value)
+            {
+                return ConvertToFlatbuffer<InnerDevType, InnerFlatbufferType>(value);
+            });
+        }
+        else if constexpr (IsVectorAndStdArray<DecayedDev, DecayedFlatBuffer>)
+        {
+            using InnerDevType = std_array_inner_type_t<DecayedDev>;
+            using InnerFlatbufferType = vector_inner_type_t<DecayedFlatBuffer>;
+
+            return TransformContainer<DecayedDev, DecayedFlatBuffer>(dev_type, [] (const InnerDevType& value)
+            {
+                return ConvertToFlatbuffer<InnerDevType, InnerFlatbufferType>(value);
+            });
+        }
+        else
+        {
+            static_assert(always_false<DevType, FlatbufferType>::value,
+               "Dev type to Flatbuffer type conversion not found in function: " __FUNCSIG__);
+        }
+    }
+
+    template <ConversionType ConversionT, NonWrappedStruct Src, NonWrappedStruct Target>
+    inline void ConvertStruct(const Src& src, Target& target)
+    {
+        using DecayedSrc = std::decay_t<decltype(src)>;
+        using DecayedTarget = std::decay_t<decltype(target)>;
+
+        constexpr size_t N = std::tuple_size_v<decltype(StructMetaData<DecayedSrc>::members)>;
+        static_assert(N == std::tuple_size_v<decltype(StructMetaData<DecayedTarget>::members)>,
+            "Source and Target structs must have the same number of fields!");
+
+        auto for_each_field = [&]<std::size_t... I>(std::index_sequence<I...>)
+        {
+            (
+                (
+                    [&]
+                    {
+                        auto& src_field = src.*(std::get<I>(StructMetaData<DecayedSrc>::members));
+                        auto& dst_field = target.*(std::get<I>(StructMetaData<DecayedTarget>::members));
+                        using DecayedSrcFieldT = std::decay_t<decltype(src_field)>;
+                        using DecayedTargetFieldT = std::decay_t<decltype(dst_field)>;
+
+                        dst_field = ConvertType<ConversionT, DecayedSrcFieldT, DecayedTargetFieldT>(src_field);
+                    }()
+                ), ...
+            );
+        };
+
+        for_each_field(std::make_index_sequence<N>{});
+    }
+}
+

--- a/src/ToolingSharedLibrary/ToolingExecutable/CodeGeneration/CppCodeBuilder.cpp
+++ b/src/ToolingSharedLibrary/ToolingExecutable/CodeGeneration/CppCodeBuilder.cpp
@@ -420,7 +420,6 @@ namespace CodeGeneration
                     c_in_and_inout_parameter_conversion_statement,
                     declaration.m_name,
                     declaration.m_name,
-                    declaration.m_name,
                     declaration.m_name);
             }
 
@@ -533,9 +532,7 @@ namespace CodeGeneration
         
         if (param_info.m_are_return_params_needed)
         {
-            updated_parameters_received_from_dev_impl << std::format(
-                c_setup_return_params_struct,
-                function_params_struct_type);
+            updated_parameters_received_from_dev_impl << c_setup_return_params_struct;
         }
         else
         {
@@ -555,13 +552,15 @@ namespace CodeGeneration
 
         // If we need to forward parameters to the developer impl or if we need to receive the return value
         // from the developer impl, we must instantiate the dev type struct associated with the function. If 
-        // neither of those things are true (e.g function that takes no args and returns no values) then we do not generate 
-        // the dev type struct variable as there is no need.
-        if (!params_to_forward.empty() || param_info.m_are_return_params_needed)
+        // neither of those things are true (e.g function that takes no in/inout args and returns no values) then 
+        // we do not generate the dev type struct variable as there is no need.
+        if (!params_to_forward.empty())
+        {
+            function_body << std::format(c_conversion_to_dev_type_statement, function_params_struct_type);
+        }
+        else if (param_info.m_are_return_params_needed)
         {
             function_body << std::format(c_instantiate_dev_type, function_params_struct_type);
-            std::string conversion_str = !params_to_forward.empty() ? c_conversion_to_dev_type_statement.data() : "";
-            function_body << conversion_str;
         }
 
         function_body << FormatString(

--- a/src/ToolingSharedLibrary/ToolingExecutable/CodeGeneration/CppCodeBuilder.cpp
+++ b/src/ToolingSharedLibrary/ToolingExecutable/CodeGeneration/CppCodeBuilder.cpp
@@ -413,11 +413,14 @@ namespace CodeGeneration
 
             AddParameterToTheForwardToDevImplList(Flatbuffers::Cpp::c_params_struct, declaration, all_params_separator, param_info);
 
-            // these will be copied into the flatbuffer
-            if (!declaration.IsOutParameterOnly())
+            // These will be copied into the flatbuffer. For Out param std::arrays we need to make sure the flatbuffer vector 
+            // that is created is of size std::array<T, N>::size() and not 0/empty so we keep the invariant that the vector.size() will always
+            // be equal to array.size() before passing the flatbuffer through the abi.
+            if (!declaration.IsOutParameterOnly() || 
+                (declaration.IsOutParameterOnly() && !declaration.m_array_dimensions.empty()))
             {
-                param_info.m_in_and_inout_param_names << std::format(
-                    c_in_and_inout_parameter_conversion_statement,
+                param_info.m_param_to_convert_names << std::format(
+                    c_parameter_conversion_statement,
                     declaration.m_name,
                     declaration.m_name,
                     declaration.m_name);
@@ -472,7 +475,7 @@ namespace CodeGeneration
         std::string parameters_using_statement = std::format(
             c_pack_params_to_flatbuffer_call,
             function_params_struct_type,
-            param_info.m_in_and_inout_param_names.str());
+            param_info.m_param_to_convert_names.str());
 
         std::ostringstream copy_and_using_statements;
 

--- a/src/ToolingSharedLibrary/ToolingExecutable/CodeGeneration/Flatbuffers/BuilderHelpers.cpp
+++ b/src/ToolingSharedLibrary/ToolingExecutable/CodeGeneration/Flatbuffers/BuilderHelpers.cpp
@@ -131,6 +131,23 @@ namespace CodeGeneration::Flatbuffers
         }
     }
 
+    std::string GetNativeInlineStringForVector(const EdlTypeInfo& info)
+    {
+        // By default for vectors of tables/structs the Flatbuffer object-api will generate the
+        // vector as a vector<unique_ptr<T>>. However when '(native_inline)' is used the api will generate the 
+        // vector as a vector<T>. We want this behavior so we can limit the amount of memory the abi allocates. 
+        // Flatbuffer generates all other types within vectors as vector<T> by default. WString is special 
+        // because we generate it as a Flatbuffer table that contains a vector of uint16's.
+        std::string inline_type_string = "";
+        if (info.m_type_kind == EdlTypeKind::Struct ||
+            info.m_type_kind == EdlTypeKind::WString)
+        {
+            inline_type_string = "(native_inline)";
+        }
+
+        return inline_type_string;
+    }
+
     std::string BuildTable(const std::vector<Declaration>& values, std::string_view struct_name)
     {
         std::ostringstream table_body {};
@@ -141,31 +158,20 @@ namespace CodeGeneration::Flatbuffers
             if (!declaration.m_array_dimensions.empty())
             {
                 table_body << std::format(
-                    "    {} : [{}];\n",
+                    "    {} : [{}] {};\n",
                     declaration.m_name,
-                    GetFlatBufferType(declaration.m_edl_type_info));
+                    GetFlatBufferType(declaration.m_edl_type_info),
+                    GetNativeInlineStringForVector(declaration.m_edl_type_info));
             }
             else if (declaration.IsEdlType(EdlTypeKind::Vector))
             {
                 auto& inner_type = declaration.m_edl_type_info.inner_type;
 
-                // By default for vectors of tables/structs the Flatbuffer object-api will generate the
-                // vector as a vector<unique_ptr<T>>. However when '(native_inline)' is used the api will generate the 
-                // vector as a vector<T>. We want this behavior so we can limit the amount of memory the abi allocates. 
-                // Flatbuffer generates all other types within vectors as vector<T> by default. WString is special 
-                // because we generate it as a Flatbuffer table that contains a vector of uint16's.
-                std::string inline_type_string = "";
-                if (inner_type->m_type_kind == EdlTypeKind::Struct || 
-                    inner_type->m_type_kind == EdlTypeKind::WString)
-                {
-                    inline_type_string = "(native_inline)";
-                }
-
                 table_body << std::format(
                     "    {} : [{}] {};\n",
                     declaration.m_name,
                     GetFlatBufferType(*inner_type),
-                    inline_type_string);
+                    GetNativeInlineStringForVector(*inner_type));
             }
             else if (declaration.IsEdlType(EdlTypeKind::Struct))
             {

--- a/src/ToolingSharedLibrary/ToolingSharedLibrary.vcxproj
+++ b/src/ToolingSharedLibrary/ToolingSharedLibrary.vcxproj
@@ -207,6 +207,7 @@
     </Text>
     <ClInclude Include="Includes\CodeGeneration\CodeGeneration.h" />
     <ClInclude Include="Includes\CodeGeneration\Contants.h" />
+    <ClInclude Include="Includes\VbsEnclaveABI\Shared\ConversionHelpers.h" />
     <ClInclude Include="Includes\VbsEnclaveABI\Shared\VbsEnclaveAbiBase.h" />
     <ClInclude Include="Includes\Edl\Parser.h" />
     <ClInclude Include="Includes\Edl\Structures.h" />

--- a/src/ToolingSharedLibrary/ToolingSharedLibrary.vcxproj.filters
+++ b/src/ToolingSharedLibrary/ToolingSharedLibrary.vcxproj.filters
@@ -78,6 +78,9 @@
     <ClInclude Include="Includes\CodeGeneration\Flatbuffers\Cpp\CppContants.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Includes\VbsEnclaveABI\Shared\ConversionHelpers.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">


### PR DESCRIPTION
### Why is this change needed
Currently for code generation we generate `ToFlatbuffer` and `ToDevType` functions within each struct that we generate (in the DeveloperType.h generated file). These structs are the structs the developer provided in their .edl file and also a struct per function.

Inside the two functions above we generate per field conversions between the dev type and the flatbuffer type. This can exponentially generate a lot of code based on the amount of fields in the structs, the amount of structs and the amount of trusted and untructed functions. To reduce this, we will now use template functions in a single header file to do the conversion. This header file will be non-generated and be a part of the ABI headers. This reduces the amount of generated code **tremendously**. For example, our biggest .edl file is the [CodeGenTestFunctions.edl](https://github.com/microsoft/VbsEnclaveTooling/blob/main/tests/EnclaveTests/CodeGenEndToEndTests/CodeGenTestFunctions.edl) file, and with our current code generation we generate `5665` lines of code. With this PR we now only generate `1268` lines. The file is also an easier read.

### What Changed?
- Added a single file `ConversionHelpers.h` file which contains all the template functions for the conversions between developer types and flatbuffer types.
- Removed the `BuildStructDefinitionForNonABIDeveloperType` and `BuildStructDefinitionForABIDeveloperType` functions in `CodeGeneration.h` since they are no longer needed and replaced them with `BuildStructMetaData` and `BuildStructDefinition` functions.
- The `BuildStructMetaData` function simply produces a small templated struct for each dev type struct and it's flatbuffer struct counterpart. In the templated struct we have a tuple of struct member pointers that we will use in the converter functions in  `ConversionHelpers.h`.
- Updated some of the strings in `Contants.h` to call our new `ConvertStruct` and `ConvertFlatbuffer` template functions in `ConversionHelpers.h`
-  The conversion functions now do not allocate memory needlessly. There are only three scenarios where `unique_ptrs` are needed and used.
    - Nested pointers inside Developer type structs
    - Nested structs within Flatbuffer structs. (See comment in `BuilderHelpers.cpp`, as this is out of our control)
    - For out params that are pointers.
- Used `(native_inline)` in flatbuffer schema for Flatbuffer structs inside vectors. This generates the vectors as `std::vector<T>` instead of `std::vector<std::unique_ptr<T>>` which is a lot more efficient and easier to work with.

### How was it tested?
- Confirmed all tests pass in `CodeGenEndToEndTests` solution
- Confirmed All sample apps are able to be built and they run successfully
- `build.ps1` script runs successfully without errors

### Fixes
- #99 
- #71 
### Future
- Another PR will be created to remove all the functions and strings that are used for the current conversion functions. I decided to do it in a separate PR since that one would be -1k lines but no additions. Figured it would be better to do it in two steps, where we add the new code first and then remove the old code so this PR stays scoped.
