### PR TITLE
Update url in the hello world sample app readme file

### DIFF
--- a/SampleApps/HelloWorld/README.md
+++ b/SampleApps/HelloWorld/README.md
@@ -2,4 +2,4 @@
 
 A simple example showing the structure of building a VBS Enclave dll and Host application.
 
-For a detailed walkthrough, please refer to the [Hello World Walkthrough](../../docs\HelloWorldWalkthrough.md)
+For a detailed walkthrough, please refer to the [Hello World Walkthrough](../../docs/HelloWorldWalkthrough.md)


### PR DESCRIPTION
- just makes the backslash into a forward slash in the readme url. The backslash caused the link to go to 

https://github.com/microsoft/VbsEnclaveTooling/blob/main/docs%5CHelloWorldWalkthrough.md

instead of

https://github.com/microsoft/VbsEnclaveTooling/blob/main/docs/HelloWorldWalkthrough.md