### PR TITLE
Remove functions and strings used to generate module.def file

### DIFF
--- a/src/ToolingSharedLibrary/Includes/CodeGeneration/CodeGeneration.h
+++ b/src/ToolingSharedLibrary/Includes/CodeGeneration/CodeGeneration.h
@@ -21,7 +21,6 @@ namespace CodeGeneration
             std::string m_vtl1_stub_functions_header_content{};
             std::ostringstream m_vtl1_developer_declaration_functions {};
             std::ostringstream m_vtl1_abi_impl_functions {};
-            std::string m_vtl1_enclave_module_definition_content {};
         };
 
         struct EnclaveToHostContent
@@ -106,8 +105,6 @@ namespace CodeGeneration
             std::string_view abi_function_to_call,
             bool is_vtl0_callback,
             const FunctionParametersInfo& param_info);
-
-        std::string BuildEnclaveModuleDefinitionFile(std::string_view exported_functions);
         
         HostToEnclaveContent BuildHostToEnclaveFunctions(
             std::string_view generated_namespace,

--- a/src/ToolingSharedLibrary/Includes/CodeGeneration/Contants.h
+++ b/src/ToolingSharedLibrary/Includes/CodeGeneration/Contants.h
@@ -24,8 +24,6 @@ namespace CodeGeneration
 
     static inline constexpr std::string_view c_output_folder_for_generated_untrusted_functions = R"(VbsEnclave\HostApp)";
 
-    static inline constexpr std::string_view c_output_module_def_file_name = "vbsenclave.def";
-
     static inline constexpr std::string_view c_abi_boundary_func_declaration = "    __declspec(dllexport) void* {}(void* function_context);\n";
 
     static inline constexpr std::string_view c_abi_boundary_func_declaration_for_stubs = "        void* {}(void* function_context);\n";

--- a/src/ToolingSharedLibrary/ToolingExecutable/CodeGeneration/CppCodeBuilder.cpp
+++ b/src/ToolingSharedLibrary/ToolingExecutable/CodeGeneration/CppCodeBuilder.cpp
@@ -494,22 +494,6 @@ namespace CodeGeneration
             function_body.str());
     }
 
-    std::string CppCodeBuilder::BuildEnclaveModuleDefinitionFile(std::string_view exported_functions)
-    {
-        auto module_def = std::format(c_enclave_def_file_content, c_autogen_header_string, exported_functions);
-
-        // Replace the // in the autogen header. This way we can have a single source for the header
-        // instead of duplicating it.
-        size_t pos = module_def.find("//");
-        while (pos != std::string::npos)
-        {
-            module_def.replace(pos, 2, ";");
-            pos = module_def.find("//", pos + 1U);
-        }
-
-        return module_def;
-    }
-
     CppCodeBuilder::HostToEnclaveContent CppCodeBuilder::BuildHostToEnclaveFunctions(
         std::string_view generated_namespace,
         const std::unordered_map<std::string, DeveloperType>& developer_types,
@@ -602,8 +586,7 @@ namespace CodeGeneration
             std::move(vtl0_class_public_portion),
             std::format("{}{}{}",c_autogen_header_string, c_vtl1_enclave_stub_includes, vtl1_stubs_in_namespace),
             std::move(vtl1_developer_declaration_functions),
-            std::move(vtl1_abi_impl_functions),
-            BuildEnclaveModuleDefinitionFile(vtl1_generated_module_exports.str())
+            std::move(vtl1_abi_impl_functions)
         };
     }
 

--- a/src/ToolingSharedLibrary/ToolingExecutable/CodeGeneration/CppCodeGenerator.cpp
+++ b/src/ToolingSharedLibrary/ToolingExecutable/CodeGeneration/CppCodeGenerator.cpp
@@ -101,11 +101,6 @@ namespace CodeGeneration
                 enclave_headers_location,
                 host_to_enclave_content.m_vtl1_stub_functions_header_content);
 
-            SaveFileToOutputFolder(
-                c_output_module_def_file_name,
-                enclave_headers_location,
-                host_to_enclave_content.m_vtl1_enclave_module_definition_content);
-
             auto vtl1_impl_header = CombineAndBuildVtl1ImplementationsHeader(
                m_generated_namespace_name,
                host_to_enclave_content.m_vtl1_developer_declaration_functions,


### PR DESCRIPTION
### Why is this change being made
Originally when we first started development on the code gen tool we generated a module.def file. During development we found an alternative way to export the generated functions from the dll and pushed the removal of the generated module.def file to a later date. Now that we have a better way to export the functions we no longer need to generate the module.def file.

### What changed
- Removed the strings and functions used to generate the module.def file 

### How was it tested
- Confirmed repository still builds and all tests in the `CodeGenEndToEndTests` solution pass. Note: none of the projects in that solution or the samples were using the generated module.def file.