### PR TITLE
Generate functions in the same order as they appear in the .edl files

### DIFF
--- a/src/ToolingExecutable/pch.h
+++ b/src/ToolingExecutable/pch.h
@@ -10,6 +10,7 @@
 #include <winerror.h>
 #include <filesystem>
 #include <format>
+#include <span>
 #include <unordered_map>
 
 #endif //PCH_H

--- a/src/ToolingSharedLibrary/Includes/CodeGeneration/CodeGeneration.h
+++ b/src/ToolingSharedLibrary/Includes/CodeGeneration/CodeGeneration.h
@@ -109,13 +109,13 @@ namespace CodeGeneration
         HostToEnclaveContent BuildHostToEnclaveFunctions(
             std::string_view generated_namespace,
             const std::unordered_map<std::string, DeveloperType>& developer_types,
-            std::unordered_map<std::string, Function>& functions);
+            std::span<Function> functions);
 
         EnclaveToHostContent BuildEnclaveToHostFunctions(
             std::string_view generated_namespace,
             std::string_view generated_class_name,
             const std::unordered_map<std::string, DeveloperType>& developer_types,
-            std::unordered_map<std::string, Function>& functions);
+            std::span<Function> functions);
 
         std::string CombineAndBuildHostAppEnclaveClass(
             std::string_view generated_class_name,
@@ -131,11 +131,11 @@ namespace CodeGeneration
 
         std::string BuildVtl1ExportedFunctionsSourcefile(
             std::string_view generated_namespace_name,
-            const std::unordered_map<std::string, Function>& developer_functions_to_export);
+            std::span<Function> developer_functions_to_export);
 
         std::string BuildVtl1BoundaryFunctionsStubHeader(
             std::string_view generated_namespace_name,
-            const std::unordered_map<std::string, Function>& functions);
+            std::span<Function> functions);
     };
 
     struct CppCodeGenerator

--- a/src/ToolingSharedLibrary/Includes/CodeGeneration/CodeGenerationHelpers.h
+++ b/src/ToolingSharedLibrary/Includes/CodeGeneration/CodeGenerationHelpers.h
@@ -92,18 +92,18 @@ namespace CodeGeneration
     }
 
     inline std::vector<DeveloperType> CreateDeveloperTypesForABIFunctions(
-        const std::unordered_map<std::string, Function>& trusted_functions,
-        const std::unordered_map<std::string, Function>& untrusted_functions)
+       std::span<Function> trusted_functions,
+       std::span<Function> untrusted_functions)
     {
         std::vector<DeveloperType> dev_types {};
 
-        for (auto [name, function] : trusted_functions)
+        for (const auto& function : trusted_functions)
         {
             DeveloperType dev_type = GetDeveloperTypeStructForABI(function);
             dev_types.push_back(dev_type);
         }
 
-        for (auto [name, function] : untrusted_functions)
+        for (const auto& function : untrusted_functions)
         {
             DeveloperType dev_type = GetDeveloperTypeStructForABI(function);
             dev_types.push_back(dev_type);

--- a/src/ToolingSharedLibrary/Includes/Edl/Parser.h
+++ b/src/ToolingSharedLibrary/Includes/Edl/Parser.h
@@ -92,7 +92,9 @@ namespace EdlProcessor
 
         std::vector<DeveloperType> m_developer_types_insertion_order_list {};
         std::unordered_map<std::string, DeveloperType> m_developer_types;
-        std::unordered_map<std::string, Function> m_trusted_functions;
-        std::unordered_map<std::string, Function> m_untrusted_functions;
+        std::unordered_map<std::string, Function> m_trusted_functions_map;
+        std::vector<Function> m_trusted_functions_list {};
+        std::unordered_map<std::string, Function> m_untrusted_functions_map;
+        std::vector<Function> m_untrusted_functions_list {};
     };
 }

--- a/src/ToolingSharedLibrary/Includes/Edl/Structures.h
+++ b/src/ToolingSharedLibrary/Includes/Edl/Structures.h
@@ -509,7 +509,9 @@ namespace EdlProcessor
         std::string m_name{};
         std::unordered_map<std::string, DeveloperType> m_developer_types{};
         std::vector<DeveloperType> m_developer_types_insertion_order_list {};
-        std::unordered_map<std::string, Function> m_trusted_functions{};
-        std::unordered_map<std::string, Function> m_untrusted_functions{};
+        std::unordered_map<std::string, Function> m_trusted_functions_map{};
+        std::vector<Function> m_trusted_functions_list {};
+        std::unordered_map<std::string, Function> m_untrusted_functions_map{};
+        std::vector<Function> m_untrusted_functions_list {};
     };
 }

--- a/src/ToolingSharedLibrary/ToolingExecutable/CodeGeneration/CppCodeBuilder.cpp
+++ b/src/ToolingSharedLibrary/ToolingExecutable/CodeGeneration/CppCodeBuilder.cpp
@@ -10,6 +10,7 @@
 #include <CodeGeneration\Flatbuffers\BuilderHelpers.h>
 #include <CodeGeneration\Flatbuffers\Contants.h>
 #include <sstream>
+
 using namespace EdlProcessor;
 using namespace CodeGeneration::Flatbuffers;
 
@@ -445,7 +446,7 @@ namespace CodeGeneration
     CppCodeBuilder::HostToEnclaveContent CppCodeBuilder::BuildHostToEnclaveFunctions(
         std::string_view generated_namespace,
         const std::unordered_map<std::string, DeveloperType>& developer_types,
-        std::unordered_map<std::string, Function>& functions)
+        std::span<Function> functions)
     {
         std::ostringstream vtl0_class_public_portion {};
         vtl0_class_public_portion << c_vtl0_enclave_class_public_keyword;
@@ -464,7 +465,7 @@ namespace CodeGeneration
 
         std::ostringstream vtl1_generated_module_exports {};
 
-        for (auto&& [name, function] : functions)
+        for (auto& function : functions)
         {
             auto param_info = GetInformationAboutParameters(function, developer_types);
             auto vtl1_exported_func_name = std::format(c_generated_stub_name, function.abi_m_name);
@@ -542,7 +543,7 @@ namespace CodeGeneration
         std::string_view generated_namespace,
         std::string_view generated_class_name,
         const std::unordered_map<std::string, DeveloperType>& developer_types,
-        std::unordered_map<std::string, Function>& functions)
+        std::span<Function> functions)
     {
         size_t number_of_functions = functions.size();
         size_t number_of_functions_plus_allocators = functions.size() + c_number_of_abi_callbacks;
@@ -580,7 +581,7 @@ namespace CodeGeneration
         // function address as the value in a map stored in vtl1. 
         auto vtl1_map_function_index = c_number_of_abi_callbacks + 1;
         auto current_iteration = 0U;
-        for (auto&& [name, function] : functions)
+        for (auto& function : functions)
         {
             auto param_info = GetInformationAboutParameters(function, developer_types);
 
@@ -723,12 +724,12 @@ namespace CodeGeneration
 
     std::string CppCodeBuilder::BuildVtl1ExportedFunctionsSourcefile(
         std::string_view generated_namespace_name,
-        const std::unordered_map<std::string, Function>& developer_functions_to_export)
+        std::span<Function> developer_functions_to_export)
     {
         std::ostringstream exported_definitions {};
         std::ostringstream pragma_link_statements {};
 
-        for (auto& [name, function] : developer_functions_to_export)
+        for (auto& function : developer_functions_to_export)
         {
             auto generated_func_name = std::format(c_generated_stub_name_no_quotes, function.abi_m_name);
             exported_definitions << std::format(
@@ -760,11 +761,11 @@ namespace CodeGeneration
 
     std::string CppCodeBuilder::BuildVtl1BoundaryFunctionsStubHeader(
         std::string_view generated_namespace_name,
-        const std::unordered_map<std::string, Function>& functions)
+        std::span<Function> functions)
     {
         std::ostringstream stub_declarations {};
 
-        for (auto& [name, function] : functions)
+        for (auto& function : functions)
         {
             auto generated_func_name = std::format(c_generated_stub_name_no_quotes, function.abi_m_name);
             stub_declarations << std::format(c_abi_boundary_func_declaration_for_stubs, generated_func_name);

--- a/src/ToolingSharedLibrary/ToolingExecutable/CodeGeneration/CppCodeGenerator.cpp
+++ b/src/ToolingSharedLibrary/ToolingExecutable/CodeGeneration/CppCodeGenerator.cpp
@@ -64,8 +64,8 @@ namespace CodeGeneration
         auto hostapp_headers_location = m_output_folder_path / hostapp_headers_output;
 
         auto abi_function_developer_types = CreateDeveloperTypesForABIFunctions(
-            m_edl.m_trusted_functions,
-            m_edl.m_untrusted_functions);
+            m_edl.m_trusted_functions_list,
+            m_edl.m_untrusted_functions_list);
 
         // Create developer types. This is shared between
         // the HostApp and the enclave.
@@ -81,14 +81,14 @@ namespace CodeGeneration
         auto host_to_enclave_content = BuildHostToEnclaveFunctions(
             m_generated_namespace_name,
             m_edl.m_developer_types,
-            m_edl.m_trusted_functions);
+            m_edl.m_trusted_functions_list);
 
         // Process the content from the untrusted functions
         auto enclave_to_host_content = BuildEnclaveToHostFunctions(
             m_generated_namespace_name, 
             m_generated_vtl0_class_name,
             m_edl.m_developer_types,
-            m_edl.m_untrusted_functions);
+            m_edl.m_untrusted_functions_list);
 
         std::filesystem::path save_location{};
 
@@ -123,7 +123,7 @@ namespace CodeGeneration
 
             std::string exported_definitions_source = BuildVtl1ExportedFunctionsSourcefile(
                 m_generated_namespace_name,
-                m_edl.m_trusted_functions);
+                m_edl.m_trusted_functions_list);
 
             SaveFileToOutputFolder(
                 std::format(c_enclave_exports_source, m_generated_namespace_name),
@@ -132,7 +132,7 @@ namespace CodeGeneration
 
             std::string boundary_stubs_header = BuildVtl1BoundaryFunctionsStubHeader(
                 m_generated_namespace_name,
-                m_edl.m_trusted_functions);
+                m_edl.m_trusted_functions_list);
 
             SaveFileToOutputFolder(
                 std::format(c_stubs_header_for_enclave_exports, m_generated_namespace_name),

--- a/src/ToolingSharedLibrary/ToolingExecutable/Edl/Parser.cpp
+++ b/src/ToolingSharedLibrary/ToolingExecutable/Edl/Parser.cpp
@@ -183,8 +183,10 @@ namespace EdlProcessor
             m_file_name.generic_string(),
             m_developer_types,
             m_developer_types_insertion_order_list,
-            m_trusted_functions,
-            m_untrusted_functions };
+            m_trusted_functions_map,
+            m_trusted_functions_list,
+            m_untrusted_functions_map,
+            m_untrusted_functions_list};
     }
 
     void EdlParser::UpdateDeveloperTypeMetadata()
@@ -428,16 +430,21 @@ namespace EdlProcessor
     void EdlParser::ParseFunctions(const FunctionKind& function_kind)
     {
         ThrowIfExpectedTokenNotNext(LEFT_CURLY_BRACKET);
-        auto& map = (function_kind == FunctionKind::Trusted)
-            ? m_trusted_functions
-            : m_untrusted_functions;
+        std::reference_wrapper<std::unordered_map<std::string, Function>> func_map = m_trusted_functions_map;
+        std::reference_wrapper<std::vector<Function>> func_list = m_trusted_functions_list;
+
+        if (function_kind == FunctionKind::Untrusted)
+        {
+            func_map = m_untrusted_functions_map;
+            func_list = m_untrusted_functions_list;
+        }
 
         while (PeekAtCurrentToken() != RIGHT_CURLY_BRACKET)
         {            
             Function parsed_function = ParseFunctionDeclaration();
             std::string function_signature = parsed_function.GetDeclarationSignature();
 
-            if (map.contains(function_signature))
+            if (func_map.get().contains(function_signature))
             {
                 throw EdlAnalysisException(
                     ErrorId::EdlDuplicateFunctionDeclaration,
@@ -458,7 +465,8 @@ namespace EdlProcessor
                 parsed_function.m_name = std::format("{}_callback", parsed_function.m_name);
             }
 
-            map.emplace(function_signature, parsed_function);
+            func_map.get().emplace(function_signature, parsed_function);
+            func_list.get().push_back(parsed_function);
         }
 
         ThrowIfExpectedTokenNotNext(RIGHT_CURLY_BRACKET);
@@ -947,12 +955,12 @@ namespace EdlProcessor
     {
         // now that we've finished parsing the function declarations and structs 
         // Make sure the size/count attributes are validated.
-        for (const auto& [function_name, function] : m_trusted_functions)
+        for (const auto& [function_name, function] : m_trusted_functions_map)
         {
             ValidateSizeAndCountAttributeDeclarations(function_name, function.m_parameters);
         }
 
-        for (const auto& [function_name, function] : m_untrusted_functions)
+        for (const auto& [function_name, function] : m_untrusted_functions_map)
         {
             ValidateSizeAndCountAttributeDeclarations(function_name, function.m_parameters);
         }

--- a/src/ToolingSharedLibrary/pch.h
+++ b/src/ToolingSharedLibrary/pch.h
@@ -10,12 +10,14 @@
 #include <filesystem>
 #include <format>
 #include <fstream>
+#include <functional>
 #include <iostream>
 #include <map>
 #include <ostream>
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <span>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>

--- a/tests/UnitTests/ToolingExecutableTests/EdlParserTestHelpers.h
+++ b/tests/UnitTests/ToolingExecutableTests/EdlParserTestHelpers.h
@@ -89,13 +89,13 @@ namespace VbsEnclaveToolingTests
 
         if (function_kind == FunctionKind::Trusted)
         {
-            Assert::IsTrue(edl.m_trusted_functions.contains(expected_signature));
-            function = edl.m_trusted_functions.at(expected_signature);
+            Assert::IsTrue(edl.m_trusted_functions_map.contains(expected_signature));
+            function = edl.m_trusted_functions_map.at(expected_signature);
         }
         else
         {
-            Assert::IsTrue(edl.m_untrusted_functions.contains(expected_signature));
-            function = edl.m_untrusted_functions.at(expected_signature);
+            Assert::IsTrue(edl.m_untrusted_functions_map.contains(expected_signature));
+            function = edl.m_untrusted_functions_map.at(expected_signature);
         }
 
          // Confirm function signature is expected signature.


### PR DESCRIPTION
### Why is this change being made
In the future we want to upload the generated code for both the enclave and the hostApp into the repository to make it easier for devs who review PRs. This will allow them to see the actual output of the generated code inside the PR itself. 

Currently the order in which we generate functions are non-deterministic because we iterate through an unordered map when generating the functions. This PR makes it so we generate functions in a deterministic order based on the order we see them in the edl file.

### What changed
- Added a `std::vector<Function>` in both the `Edl` struct and `Parser` class to store the functions in the order they are seen in the edl file.
- Used the vector to add `Functions` in the order we see them in the `ParseFunctions` function in `Parser.cpp`
- Updated functions in `CodeGeneration.h` that take `std::unordered<string, Function>` to `span<Function>` , and passed the vector of functions in the `Edl` struct to those functions instead of the map.

### How was this tested
- Ran the build script and confirmed the it runs successfully. Also ran the CodeGen tests and confirmed they all passed successfully

### Next steps
- Uploading the generated code for both the enclave and the hostApp into the repository to make it easier for devs who review PRs.