### PR TITLE
Add hardening macros to build props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,10 +24,7 @@
       <WarningLevel>Level4</WarningLevel>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard Condition="'$(CppWinRTLanguageStandard)'==''">stdcpp17</LanguageStandard>
-      <LanguageStandard Condition="'$(CppWinRTLanguageStandard)'=='20'">stdcpp20</LanguageStandard>
-      <PreprocessorDefinitions Condition="'$(Configuration)'=='Debug'">DEBUG=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(Configuration)'!='Debug'">%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MSVC_STL_HARDENING=1;_MSVC_STL_DESTRUCTOR_TOMBSTONES=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AdditionalOptions>/bigobj</AdditionalOptions>
     </ClCompile>


### PR DESCRIPTION
### Why is this change needed?
To add C++ STL hardening to the code base

### What changed.
- Updated the `Directory.Build.props` to add the following `_MSVC_STL_HARDENING=1;_MSVC_STL_DESTRUCTOR_TOMBSTONES=1`
- Removed the `LanguageStandard` conditions as they were from the cppwinrt repo, and not used in this repo.
- we now only have one `PreprocessorDefinitions` attribute instead of one for debug and one for everything else. `Note`: the old  debug one had a `Debug` flag that was from the cpp winrt repo as well which is also unused by this repo. VS automatically adds the `_Debug` to the preprocessor attribute. 

### How was this tested?
- Confirmed I was able to build the samples, tooling, codegen test and veil solutions.
- For each of the above I checked the generated `.binlog` files to confirm the macros were used in each of the builds.
