### PR TITLE
Update EDL Parser: Functions can now return Pointers; Structs can now contain pointers to not yet defined structs

### DIFF
--- a/src/ToolingSharedLibrary/Includes/Edl/Parser.h
+++ b/src/ToolingSharedLibrary/Includes/Edl/Parser.h
@@ -53,6 +53,7 @@ namespace EdlProcessor
             const std::vector<Declaration>& declarations);
             
         void ValidateNonSizeAndCountAttributes(const Declaration& declaration);
+        void UpdateTypeDeclarations(std::span<Declaration> declarations);
 
         inline void ThrowIfExpectedTokenNotNext(const char* token_expected_next);
         inline void ThrowIfExpectedTokenNotNext(char token_expected_next);
@@ -96,5 +97,6 @@ namespace EdlProcessor
         std::vector<Function> m_trusted_functions_list {};
         std::unordered_map<std::string, Function> m_untrusted_functions_map;
         std::vector<Function> m_untrusted_functions_list {};
+        std::unordered_set<std::string> m_unresolved_types{};
     };
 }

--- a/src/ToolingSharedLibrary/Includes/ErrorHelpers.h
+++ b/src/ToolingSharedLibrary/Includes/ErrorHelpers.h
@@ -51,7 +51,6 @@ namespace ErrorHelpers
         EdlDuplicateAttributeFound,
         EdlSizeOrCountAttributeValueMissing,
         EdlPointerToPointerInvalid,
-        EdlDeveloperTypesMustBeDefinedBeforeUse,
         EdlTypenameInvalid,
         EdlArrayDimensionIdentifierInvalid,
         EdlOnlySingleDimensionsSupported,
@@ -67,7 +66,6 @@ namespace ErrorHelpers
         EdlEnumNameDuplicated,
         EdlDuplicateFieldOrParameter,
         EdlSizeAndCountNotValidForNonPointer,
-        EdlReturnValuesCannotBePointers,
         CodeGenUnableToOpenOutputFile,
         CodeGenUnableToCreateHeaderFile,
         VirtualTrustLayerNoMoreArgs,
@@ -81,7 +79,7 @@ namespace ErrorHelpers
         EdlVectorMustHaveAValidType,
         EdlVectorNameIdentifierNotFound,
         EdlVectorDoesNotStartWithArrowBracket,
-        EdlTypeInVectorMustBePreviouslyDefined,
+        EdlStructSelfReference,
     };
 
     struct ErrorIdHash
@@ -133,7 +131,7 @@ namespace ErrorHelpers
         { ErrorId::EdlDuplicateAttributeFound, "Duplicate '{}' attributes for a struct declaration or a function parameter are not allowed." },
         { ErrorId::EdlSizeOrCountAttributeValueMissing, "the {} attribute is not supported." },
         { ErrorId::EdlPointerToPointerInvalid, "VbsEnclaveTooling .edl files do not support pointer to pointer declarations." },
-        { ErrorId::EdlTypenameInvalid, "Reached end of file and no definition was found for type '{}'." },
+        { ErrorId::EdlTypenameInvalid, "Reached end of file and no definition was found for the following types: '{}'." },
         { ErrorId::EdlArrayDimensionIdentifierInvalid, "'{}' not supported within array brackets. Arrays in VbsEnclaveTooling .edl files only support arrays with an integer literal '[5]' and arrays with string literals previously declared in the edl file e.g. '[int_max]'." },
         { ErrorId::EdlPointerMustBeAnnotatedWithDirection, "Pointers must have a pointer direction. Use the 'in' or 'out' attribute." },
         { ErrorId::EdlPointerToArrayNotAllowed, "VbsEnclaveTooling .edl files do not support the pointers to arrays or vectors." },
@@ -146,14 +144,12 @@ namespace ErrorHelpers
         { ErrorId::EdlEnumNameDuplicated, "'{}' enum value already defined." },
         { ErrorId::EdlDuplicateFieldOrParameter, "duplicate name '{}' found in '{}'." },
         { ErrorId::EdlSizeAndCountNotValidForNonPointer, "Size/count attributes are only valid for pointer types. Found type '{}'" },
-        { ErrorId::EdlReturnValuesCannotBePointers, "Functions cannot return a pointer. Instead return a struct that contains the pointer and the size of the data it points to." },
         { ErrorId::EdlPointerToVoidMustBeAnnotated, "Pointers to void are not allowed. To use a pointer that does not have a type use the 'uintptr_t' type. Note: The codegen layer will only copy the 'uintptr_t' type, not the data it points to." },
         { ErrorId::EdlOnlySingleDimensionsSupported, "Only linear arrays and vectors are supported." },
-        { ErrorId::EdlDeveloperTypesMustBeDefinedBeforeUse, "Developer types must be defined before using. Found '{}'" },
         { ErrorId::EdlVectorMustHaveAValidType, "Vector must contain a valid type." },
         { ErrorId::EdlVectorNameIdentifierNotFound, "Expected an identifier name for a vector but found '{}'" },
-        { ErrorId::EdlTypeInVectorMustBePreviouslyDefined, "Types in vectors must be previously defined. Found '{}'" },
         { ErrorId::EdlVectorDoesNotStartWithArrowBracket, "Vectors must be declared with <T>. where T is a valid type" },
+        { ErrorId::EdlStructSelfReference, "A struct cannot contain itself directly. Use a pointer to the struct instead." },
 
         // CodeGen errors
         { ErrorId::CodeGenUnableToOpenOutputFile, "Failed to open '{}' for writing." },

--- a/src/ToolingSharedLibrary/ToolingExecutable/Edl/Parser.cpp
+++ b/src/ToolingSharedLibrary/ToolingExecutable/Edl/Parser.cpp
@@ -419,6 +419,18 @@ namespace EdlProcessor
             {
                 new_struct_type.m_contains_container_type = true;
             }
+
+            auto is_field_type_same_as_struct = field.m_edl_type_info.m_name == new_struct_type.m_name;
+
+            // Ensure no field contains the struct type itself, unless it's a pointer to the struct.
+            if (is_field_type_same_as_struct && !field.m_edl_type_info.is_pointer)
+            {
+                throw EdlAnalysisException(
+                    ErrorId::EdlStructSelfReference,
+                    m_file_name,
+                    m_cur_line,
+                    m_cur_column);
+            }
         }
 
         ThrowIfExpectedTokenNotNext(RIGHT_CURLY_BRACKET);
@@ -477,25 +489,12 @@ namespace EdlProcessor
         attribute_info.m_in_and_out_present = false;
         function.m_return_info.m_attribute_info = attribute_info;
         function.m_return_info.m_name = "_return_value_";
+        ValidatePointers(function.m_return_info);
 
         Token function_name_token = GetCurrentTokenAndMoveToNextToken();
         ThrowIfTokenNotIdentifier(function_name_token, ErrorId::EdlFunctionIdentifierNotFound);
         function.m_name = function_name_token.ToString();
         
-        // Return of pointers aren't allowed. Only primitive types and structs as values. Pointers
-        // in structs must have a an associated size/count attribute, so by preventing the return of pointers directly
-        // developers must enclose them in structs. This way the abi layer can properly copy the underlying memory to 
-        // the appropriate virtual trust layer as it will know the size of the data the pointer points to.
-        if (function.m_return_info.m_edl_type_info.is_pointer)
-        {
-            throw EdlAnalysisException(
-                ErrorId::EdlReturnValuesCannotBePointers,
-                m_file_name,
-                m_cur_line,
-                m_cur_column,
-                function.m_name);
-        }
-
         ThrowIfTypeNameIdentifierIsReserved(function.m_name);
         ThrowIfExpectedTokenNotNext(LEFT_ROUND_BRACKET);
 
@@ -661,7 +660,7 @@ namespace EdlProcessor
         Token type_token = GetCurrentTokenAndMoveToNextToken();
         ThrowIfTokenNotIdentifier(type_token, ErrorId::EdlIdentifierNameNotFound);
         auto type_name = type_token.ToString();
-        auto type_info = EdlTypeInfo(type_name);
+        auto type_info = EdlTypeInfo(type_name, EdlTypeKind::Unknown);
 
         // Check if type is a keyword for a type we support out of the box by default within
         // function parameters and structs. E.g uint8_t
@@ -683,16 +682,6 @@ namespace EdlProcessor
             DeveloperType& developer_type = m_developer_types.at(type_name);
             type_info.m_type_kind = developer_type.m_type_kind;
         }
-        else
-        {
-            // Custom type that isn't defined yet.
-            throw EdlAnalysisException(
-                ErrorId::EdlDeveloperTypesMustBeDefinedBeforeUse,
-                m_file_name,
-                m_cur_line,
-                m_cur_column,
-                type_name);
-        }
 
         // Add the pointer if it exists.
         if (PeekAtCurrentToken() == ASTERISK)
@@ -709,6 +698,18 @@ namespace EdlProcessor
                     m_cur_line,
                     m_cur_column);
             }
+        }
+
+        // Make sure we cover inner type case E.g vector<type>.
+        auto* cur_info = &type_info;
+        if (cur_info->inner_type)
+        {
+            cur_info = cur_info->inner_type.get();
+        }
+
+        if (!m_unresolved_types.contains(cur_info->m_name) && cur_info->m_type_kind == EdlTypeKind::Unknown)
+        {
+            m_unresolved_types.insert(cur_info->m_name);
         }
 
         return type_info;
@@ -823,12 +824,7 @@ namespace EdlProcessor
             }
             else
             {
-                throw EdlAnalysisException(
-                    ErrorId::EdlTypeInVectorMustBePreviouslyDefined,
-                    m_file_name,
-                    m_cur_line,
-                    m_cur_column,
-                    token_name);
+                vector_info.inner_type = std::make_shared<EdlTypeInfo>(token_name, EdlTypeKind::Unknown);
             }
 
             ThrowIfExpectedTokenNotNext(RIGHT_ARROW_BRACKET);
@@ -945,8 +941,69 @@ namespace EdlProcessor
         return {};
     }
 
+    void EdlParser::UpdateTypeDeclarations(std::span<Declaration> declarations)
+    {
+        std::vector<std::string> resolved_types {};
+
+        for (auto& declaration : declarations)
+        {
+            auto type_info_ptr = &declaration.m_edl_type_info;
+
+            // Cover vector<type> case.
+            if (type_info_ptr->inner_type)
+            {
+                type_info_ptr = type_info_ptr->inner_type.get();
+            }
+
+            auto type_name_found = declaration.m_edl_type_info.m_name;
+            auto type_name_is_unresolved = m_unresolved_types.contains(type_name_found);
+            auto dev_type_iter = m_developer_types.find(type_name_found);
+            auto type_name_is_dev_type = dev_type_iter != m_developer_types.end();
+
+            if (type_name_is_unresolved && type_name_is_dev_type)
+            {
+                type_info_ptr->m_type_kind = dev_type_iter->second.m_type_kind;
+                resolved_types.push_back(type_name_found);
+            }
+        }
+
+        for (auto& name : resolved_types)
+        {
+            m_unresolved_types.erase(name);
+        }
+    }
+
     void EdlParser::PerformFinalValidations()
     {
+        for (auto& dev_type : m_developer_types_insertion_order_list)
+        {
+            UpdateTypeDeclarations(dev_type.m_fields);
+        }
+
+        for (auto& vec : {std::ref(m_trusted_functions_list), std::ref(m_untrusted_functions_list)})
+        {
+            for (auto& function : vec.get())
+            {
+                UpdateTypeDeclarations(function.m_parameters);
+            }
+        }
+
+        if (!m_unresolved_types.empty())
+        {
+            std::string type_names;
+            for (const auto& type_name : m_unresolved_types)
+            {
+                type_names += (type_names.empty() ? "" : ", ") + type_name;
+            }
+
+            throw EdlAnalysisException(
+                ErrorId::EdlTypenameInvalid,
+                m_file_name,
+                m_cur_line,
+                m_cur_column,
+                type_names);
+        }
+        
         // now that we've finished parsing the function declarations and structs 
         // Make sure the size/count attributes are validated.
         for (const auto& [function_name, function] : m_trusted_functions_map)

--- a/tests/EnclaveTests/CodeGenEndToEndTests/CodeGenTestFunctions.edl
+++ b/tests/EnclaveTests/CodeGenEndToEndTests/CodeGenTestFunctions.edl
@@ -53,11 +53,6 @@ enclave
         HRESULT result;
     };
 
-    struct Int8PtrAndSize
-    {
-        int8_t* int8_val;
-    };
-
     struct NestedStructWithArray
     {
         int64_t array1[value1];
@@ -102,16 +97,16 @@ enclave
         TestStruct2 field5;
     };
 
+    struct StructWithPointers
+    {
+        NestedStructWithPointers* nested_struct_ptr;
+    };
+
     struct NestedStructWithPointers
     {
         int32_t* int32_ptr;
         DecimalEnum* deci_ptr;
         TestStruct1* struct_ptr;
-    };
-
-    struct StructWithPointers
-    {
-        NestedStructWithPointers* nested_struct_ptr;
     };
 
     // Host to enclave functions
@@ -151,10 +146,9 @@ enclave
             [out] DecimalEnum* enum_val,
             [out] uint64_t* uint64_val); 
 
-        // Example of returning a pointer since we don't allow return pointers of primitives, 
-        // only structs. Pointer marhaling works the same way for primitive so we only need a test
+        // Example of returning a pointer. Marshalling works the same way for primitive so we only need a test
         // for one.
-        Int8PtrAndSize ReturnInt8ValPtr_From_Enclave();
+        int32_t* ReturnInt32Ptr_From_Enclave();
 
         uint64_t ReturnUint64Val_From_Enclave();
 
@@ -233,7 +227,7 @@ enclave
         HRESULT Start_TestPassingPrimitivesAsInPointers_To_HostApp_Callback_Test();
         HRESULT Start_TestPassingPrimitivesAsInOutPointers_To_HostApp_Callback_Test();
         HRESULT Start_TestPassingPrimitivesAsOutPointers_To_HostApp_Callback_Test(); 
-        HRESULT Start_ReturnInt8ValPtr_From_HostApp_Callback_Test();
+        HRESULT Start_ReturnInt32Ptr_From_HostApp_Callback_Test();
         HRESULT Start_ReturnUint64Val_From_HostApp_Callback_Test();
         HRESULT Start_ReturnStructWithValues_From_HostApp_Callback_Test();
         HRESULT Start_ComplexPassingOfTypes_To_HostApp_Callback_Test();
@@ -285,10 +279,9 @@ enclave
             [out] DecimalEnum* enum_val,
             [out] uint64_t* uint64_val); 
 
-        // Example of returning a pointer since we don't allow return pointers of primitives, 
-        // only structs. Pointer marhaling works the same way for primitive so we only need a test
+        // Example of returning a pointer. Marshalling works the same way for primitive so we only need a test
         // for one.
-        Int8PtrAndSize ReturnInt8ValPtr_From_HostApp();
+        int32_t* ReturnInt32Ptr_From_HostApp();
 
         uint64_t ReturnUint64Val_From_HostApp();
 

--- a/tests/EnclaveTests/CodeGenEndToEndTests/TestEnclave/Vtl1ExportsImplementations.cpp
+++ b/tests/EnclaveTests/CodeGenEndToEndTests/TestEnclave/Vtl1ExportsImplementations.cpp
@@ -48,13 +48,9 @@ HRESULT inline VerifyContainsSameValuesArray(const T* data, size_t size, T value
 
 #pragma region VTL1 Enclave developer implementation functions
 
-Int8PtrAndSize Trusted::Implementation::ReturnInt8ValPtr_From_Enclave()
+std::unique_ptr<std::int32_t> Trusted::Implementation::ReturnInt32Ptr_From_Enclave()
 {
-    Int8PtrAndSize ret {};
-    ret.int8_val = std::make_unique<std::int8_t>();
-    *ret.int8_val = std::numeric_limits<std::int8_t>::max();
-
-    return ret;
+    return std::make_unique<std::int32_t>(std::numeric_limits<std::int32_t>::max());
 }
 
 std::uint64_t Trusted::Implementation::ReturnUint64Val_From_Enclave()
@@ -374,12 +370,12 @@ StructWithPointers Trusted::Implementation::ComplexPassingOfTypesThatContainPoin
 // For testing vtl0 callbacks we use HRESULTS as our success/failure metrics since we can't use TAEF in the
 // enclave.
 
-HRESULT Trusted::Implementation::Start_ReturnInt8ValPtr_From_HostApp_Callback_Test()
+HRESULT Trusted::Implementation::Start_ReturnInt32Ptr_From_HostApp_Callback_Test()
 {
     // Note: struct is returned by vtl1, and copied to vtl0 then returned to this function.
-    Int8PtrAndSize result = Untrusted::Stubs::ReturnInt8ValPtr_From_HostApp();
-    THROW_HR_IF_NULL(E_INVALIDARG, result.int8_val);
-    THROW_HR_IF(E_INVALIDARG, *result.int8_val != std::numeric_limits<std::int8_t>::max());
+    auto result = Untrusted::Stubs::ReturnInt32Ptr_From_HostApp();
+    THROW_HR_IF_NULL(E_INVALIDARG, result.get());
+    THROW_HR_IF(E_INVALIDARG, *result != std::numeric_limits<std::int32_t>::max());
 
     return S_OK;
 }

--- a/tests/EnclaveTests/CodeGenEndToEndTests/TestHostApp/TestEnclaveTaefTests.cpp
+++ b/tests/EnclaveTests/CodeGenEndToEndTests/TestHostApp/TestEnclaveTaefTests.cpp
@@ -108,14 +108,14 @@ struct EnclaveTestClass
         return VERIFY_SUCCEEDED(generated_enclave_class.RegisterVtl0Callbacks());
     }
 
-    TEST_METHOD(ReturnInt8ValPtr_From_Enclave_Test)
+    TEST_METHOD(ReturnInt32ValPtr_From_Enclave_Test)
     {
         auto generated_enclave_class = TestEnclave(m_enclave);
 
-        // Note: Int8PtrAndSize is returned by vtl1, and copied to vtl0 then returned to this function.
-        Int8PtrAndSize result = generated_enclave_class.ReturnInt8ValPtr_From_Enclave();
-        VERIFY_IS_NOT_NULL(result.int8_val.get());
-        VERIFY_ARE_EQUAL(*result.int8_val, std::numeric_limits<std::int8_t>::max());
+        // Note: the int8_t unique ptr is returned by vtl1, and copied to vtl0 then returned to this function.
+        auto result = generated_enclave_class.ReturnInt32Ptr_From_Enclave();
+        VERIFY_IS_NOT_NULL(result.get());
+        VERIFY_ARE_EQUAL(*result, std::numeric_limits<std::int32_t>::max());
     }
 
     TEST_METHOD(ReturnUint64Val_From_Enclave_Test)
@@ -562,12 +562,12 @@ struct EnclaveTestClass
         VERIFY_SUCCEEDED(generated_enclave_class.Start_TestPassingPrimitivesAsOutPointers_To_HostApp_Callback_Test());
     }
 
-    TEST_METHOD(Start_ReturnInt8ValPtr_From_HostApp_Callback_Test)
+    TEST_METHOD(Start_ReturnInt32Ptr_From_HostApp_Callback_Test)
     {
         auto generated_enclave_class = TestEnclave(m_enclave);
 
         // Note: Hresult is returned by vtl1, and copied to vtl0 then returned to this function.
-        VERIFY_SUCCEEDED(generated_enclave_class.Start_ReturnInt8ValPtr_From_HostApp_Callback_Test());
+        VERIFY_SUCCEEDED(generated_enclave_class.Start_ReturnInt32Ptr_From_HostApp_Callback_Test());
     }
 
     TEST_METHOD(Start_ReturnUint64Val_From_HostApp_Callback_Test)

--- a/tests/EnclaveTests/CodeGenEndToEndTests/TestHostApp/TestHelpers.h
+++ b/tests/EnclaveTests/CodeGenEndToEndTests/TestHostApp/TestHelpers.h
@@ -225,7 +225,10 @@ inline bool CompareTestStruct1(TestStruct1 a, TestStruct1 b)
 
     if (a.array1.size() == b.array1.size())
     {
-        return std::equal(a.array1.begin(), a.array1.end(), b.array1.begin());
+        if (!std::equal(a.array1.begin(), a.array1.end(), b.array1.begin()))
+        {
+            return false;
+        }
     }
     else
     {

--- a/tests/EnclaveTests/CodeGenEndToEndTests/TestHostApp/Vtl0CallbackImplementations.cpp
+++ b/tests/EnclaveTests/CodeGenEndToEndTests/TestHostApp/Vtl0CallbackImplementations.cpp
@@ -17,13 +17,9 @@ using namespace VbsEnclave;
 
 #pragma region VTL0 (HostApp) Callback implementations
 
-Int8PtrAndSize Untrusted::Implementation::ReturnInt8ValPtr_From_HostApp()
+std::unique_ptr<std::int32_t> Untrusted::Implementation::ReturnInt32Ptr_From_HostApp()
 {
-    Int8PtrAndSize ret {};
-    ret.int8_val = std::make_unique<std::int8_t>();
-    *ret.int8_val = std::numeric_limits<std::int8_t>::max();
-
-    return ret;
+    return std::make_unique<std::int32_t>(std::numeric_limits<std::int32_t>::max());
 }
 
 std::uint64_t Untrusted::Implementation::ReturnUint64Val_From_HostApp()

--- a/tests/UnitTests/TestFiles/BasicTypesTest.edl
+++ b/tests/UnitTests/TestFiles/BasicTypesTest.edl
@@ -44,6 +44,8 @@ enclave
         uint32_t RetUint32_t();
         uint64_t RetUint64_t();
         void RetVoid();
+
+        uint32_t* RetUint32Ptr();
     };
 
     untrusted 
@@ -80,5 +82,7 @@ enclave
         uint32_t RetUint32_t();
         uint64_t RetUint64_t();
         void RetVoid();
+
+        uint32_t* RetUint32Ptr();
     };
 };

--- a/tests/UnitTests/TestFiles/EnumTest.edl
+++ b/tests/UnitTests/TestFiles/EnumTest.edl
@@ -63,6 +63,8 @@ enclave
             size_t arg20,
             size_t arg21
         );
+
+        Color* GetColorPtr();
     };
 
     untrusted 
@@ -102,5 +104,7 @@ enclave
             size_t arg20,
             size_t arg21
         );
+
+        Color* GetColorPtr();
     };
 };

--- a/tests/UnitTests/TestFiles/StructTest.edl
+++ b/tests/UnitTests/TestFiles/StructTest.edl
@@ -12,12 +12,19 @@ enclave
     struct MyStruct0
     {
         int32_t x;
+        MyStruct2* mystruct2_ptr;
+        vector<MyStruct2> mystruct2_vec;
     };
 
     struct MyStruct1
     {
         MyStruct0 s0;
         int32_t y;
+    };
+
+    struct MyStruct2
+    {
+        MyStruct2* mystruct2;
     };
 
     trusted 
@@ -53,6 +60,8 @@ enclave
             size_t arg20,
             size_t arg21
         );
+
+         MyStruct1* GetStruct1Ptr();
     };
 
     untrusted
@@ -88,5 +97,7 @@ enclave
             size_t arg20,
             size_t arg21
         );
+
+        MyStruct1* GetStruct1Ptr();
     };
 };

--- a/tests/UnitTests/ToolingExecutableTests/EdlParserArrayTests.cpp
+++ b/tests/UnitTests/ToolingExecutableTests/EdlParserArrayTests.cpp
@@ -84,9 +84,8 @@ TEST_CLASS(EdlParserArrayTests)
 
     TEST_METHOD(Parse_ArrayUint64_t_Trusted_Function)
     {
-        ParseAndValidateTestFunction(m_array_edl_file_name, "ArrayUint64_t", FunctionKind::Untrusted, EdlTypeKind::Void);
+        ParseAndValidateTestFunction(m_array_edl_file_name, "ArrayUint64_t", FunctionKind::Trusted, EdlTypeKind::Void);
     }
-
 
     // Untrusted functions
 

--- a/tests/UnitTests/ToolingExecutableTests/EdlParserBasicTypesTests.cpp
+++ b/tests/UnitTests/ToolingExecutableTests/EdlParserBasicTypesTests.cpp
@@ -102,6 +102,11 @@ TEST_CLASS(EdlParserBasicTypesTests)
         ParseAndValidateTestFunction(m_basic_edl_file_name, "RetVoid", FunctionKind::Trusted, EdlTypeKind::Void);
     }
 
+    TEST_METHOD(Parse_RetUint32Ptr_Trusted_Function)
+    {
+        ParseAndValidateTestFunction(m_basic_edl_file_name, "RetUint32Ptr", FunctionKind::Trusted, EdlTypeKind::UInt32, FunctionReturnKind::Ptr);
+    }
+
     // Untrusted functions
 
     TEST_METHOD(Parse_UntrustedWithBasicTypes_Function)
@@ -177,6 +182,11 @@ TEST_CLASS(EdlParserBasicTypesTests)
     TEST_METHOD(Parse_RetVoid_Untrusted_Function)
     {
         ParseAndValidateTestFunction(m_basic_edl_file_name, "RetVoid", FunctionKind::Untrusted, EdlTypeKind::Void);
+    }
+
+    TEST_METHOD(Parse_RetUint32Ptr_Untrusted_Function)
+    {
+        ParseAndValidateTestFunction(m_basic_edl_file_name, "RetUint32Ptr", FunctionKind::Untrusted, EdlTypeKind::UInt32, FunctionReturnKind::Ptr);
     }
 };
 }

--- a/tests/UnitTests/ToolingExecutableTests/EdlParserEnumTypeTests.cpp
+++ b/tests/UnitTests/ToolingExecutableTests/EdlParserEnumTypeTests.cpp
@@ -32,11 +32,21 @@ TEST_CLASS(EdlParserEnumTypeTests)
         ParseAndValidateTestFunction(m_enum_edl_file_name, "TrustedGetColor", FunctionKind::Trusted, EdlTypeKind::Enum);
     }
 
+    TEST_METHOD(Parse_TrustedGetColorPtr_Function)
+    {
+        ParseAndValidateTestFunction(m_enum_edl_file_name, "GetColorPtr", FunctionKind::Trusted, EdlTypeKind::Enum, FunctionReturnKind::Ptr);
+    }
+
     // Untrusted functions
 
     TEST_METHOD(Parse_UntrustedGetColor_Function)
     {
         ParseAndValidateTestFunction(m_enum_edl_file_name, "UntrustedGetColor", FunctionKind::Untrusted, EdlTypeKind::Enum);
     }    
+
+    TEST_METHOD(Parse_UntrustedGetColorPtr_Function)
+    {
+        ParseAndValidateTestFunction(m_enum_edl_file_name, "GetColorPtr", FunctionKind::Untrusted, EdlTypeKind::Enum, FunctionReturnKind::Ptr);
+    }
 };
 }

--- a/tests/UnitTests/ToolingExecutableTests/EdlParserStructTypesTests.cpp
+++ b/tests/UnitTests/ToolingExecutableTests/EdlParserStructTypesTests.cpp
@@ -31,12 +31,21 @@ TEST_CLASS(EdlParserStructTypeTests)
         ParseAndValidateTestFunction(m_struct_edl_file_name, "TrustedGetStruct1", FunctionKind::Trusted, EdlTypeKind::Struct);
     }
 
+    TEST_METHOD(Parse_TrustedGetStruct1Ptr_Function)
+    {
+        ParseAndValidateTestFunction(m_struct_edl_file_name, "GetStruct1Ptr", FunctionKind::Trusted, EdlTypeKind::Struct, FunctionReturnKind::Ptr);
+    }
 
     // Untrusted functions
 
     TEST_METHOD(Parse_UntrustedGetStruct1_Function)
     {
         ParseAndValidateTestFunction(m_struct_edl_file_name, "UntrustedGetStruct1", FunctionKind::Untrusted, EdlTypeKind::Struct);
+    }
+
+    TEST_METHOD(Parse_UntrustedGetStruct1Ptr_Function)
+    {
+        ParseAndValidateTestFunction(m_struct_edl_file_name, "GetStruct1Ptr", FunctionKind::Untrusted, EdlTypeKind::Struct, FunctionReturnKind::Ptr);
     }
 };
 }

--- a/tests/UnitTests/ToolingExecutableTests/EdlParserTestHelpers.h
+++ b/tests/UnitTests/ToolingExecutableTests/EdlParserTestHelpers.h
@@ -54,16 +54,25 @@ namespace VbsEnclaveToolingTests
         { "RetUint32_t", "RetUint32_t()" },
         { "RetUint64_t", "RetUint64_t()" },
         { "RetVoid", "RetVoid()" },
+        { "RetUint32Ptr", "RetUint32Ptr()" },
 
         // EnumTest.edl function signatures where key is function name and value is its signature
 
         {"TrustedGetColor", "TrustedGetColor(Color,Color[Nine],Color[5],Color[1],Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,size_t,size_t)"},
         {"UntrustedGetColor", "UntrustedGetColor(Color,Color[5],Color[5],Color[1],Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,Color*,size_t,size_t)"},
+        { "GetColorPtr", "GetColorPtr()" },
 
         // StructTest.edl function signatures where key is function name and value is its signature
 
         {"TrustedGetStruct1", "TrustedGetStruct1(MyStruct1,MyStruct1[5],MyStruct1[5],MyStruct1[1],MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,size_t,size_t)"},
         {"UntrustedGetStruct1", "UntrustedGetStruct1(MyStruct1,MyStruct1[5],MyStruct1[5],MyStruct1[1],MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,size_t,size_t)"},
+        { "GetStruct1Ptr", "GetStruct1Ptr()" },
+    };
+
+    enum class FunctionReturnKind
+    {
+        NonPtr,
+        Ptr,
     };
 
     static inline std::wstring ConvertExceptionMessageToWstring(const std::exception& exception)
@@ -108,7 +117,8 @@ namespace VbsEnclaveToolingTests
         const std::filesystem::path& test_file_name,
         const std::string& function_name,
         const FunctionKind& function_kind,
-        const EdlTypeKind& expected_return_type)
+        const EdlTypeKind& expected_return_type,
+        FunctionReturnKind return_kind = FunctionReturnKind::NonPtr)
     {
         try
         {
@@ -128,6 +138,15 @@ namespace VbsEnclaveToolingTests
             auto actual_return_type_string = c_edlTypes_to_string_map.at(function.m_return_info.m_edl_type_info.m_type_kind);
             auto expected_return_type_string = c_edlTypes_to_string_map.at(expected_return_type);
             Assert::AreEqual(expected_return_type_string, actual_return_type_string);
+
+            if (return_kind == FunctionReturnKind::NonPtr)
+            {
+                Assert::IsFalse(function.m_return_info.HasPointer());
+            }
+            else
+            {
+                Assert::IsTrue(function.m_return_info.HasPointer());
+            }
         }
         catch (const std::exception& exception)
         {

--- a/tests/UnitTests/ToolingExecutableTests/LexicalAnalyzerTests.cpp
+++ b/tests/UnitTests/ToolingExecutableTests/LexicalAnalyzerTests.cpp
@@ -33,6 +33,8 @@ TEST_CLASS(LexicalAnalyzerTests)
             LEFT_ROUND_BRACKET,
             RIGHT_SQUARE_BRACKET,
             LEFT_SQUARE_BRACKET,
+            RIGHT_ARROW_BRACKET,
+            LEFT_ARROW_BRACKET,
             EQUAL_SIGN,
             SEMI_COLON,
             COMMA,

--- a/tests/UnitTests/pch.h
+++ b/tests/UnitTests/pch.h
@@ -7,9 +7,10 @@
 #define PCH_H
 
 #include <filesystem>
-#include <string>
-#include <iostream>
 #include <fstream> 
+#include <iostream>
+#include <span>
+#include <string>
 #include <unordered_map>
 
 #endif //PCH_H


### PR DESCRIPTION
## Why is this change needed?
There is no reason for us to not allow functions in edls to return pointers. No change to the codegen in needed for this. Now devs don't need to make a struct with a pointer inside, just so they can return a pointer from a function.

Also before this change the parser errors out if it sees a type that has not been defined yet. E.g
```C++
struct A
{
    B* b;
};
struct B
{
    // fields
};
```
would cause an error since the parser will parse `A` first but since it never saw `B` up to that point, it will error out while parsing `A`'s fields. Now the parser will allow this.

## What changed?
- Removed the code that throws an exception if we see a function returning a pointer
- Updated parser to allow the scenario above. We will validate that all types exist only after parsing the whole file.
- Updated the codegen tests that returned the `Int8PtrAndSize` struct to now just return a `uint32_t*`
- Updated parser unit tests to account for function return pointers.
- Updated the `StructTests.edl` file  for the parser unit tests so that `MyStruct0` is like struct `A` and the `MyStruct2` struct is like struct `B` in the scenario above.
- I did the same thing for the `StructWithPointers` and the `NestedStructWithPointers` in the `CodeGenTestFunctions.edl` (Codegen test solution)  as well.

## How was it tested?
- Built and ran the codegen tests and confirmed they all still pass.
- Ran the  parser unit tests via VS Test explorer and confirmed they all passed still