### PR TITLE
Update Edl Parser: Add ability to import one or more edl files

### DIFF
--- a/src/ToolingExecutable/main.cpp
+++ b/src/ToolingExecutable/main.cpp
@@ -33,7 +33,7 @@ int main(int argc, char* argv[])
 
     try
     {
-        auto edl_parser = EdlParser(argument_parser.EdlFilePath());
+        auto edl_parser = EdlParser(argument_parser.EdlFilePath(), argument_parser.ImportDirectories());
         Edl edl = edl_parser.Parse();
 
         auto cpp_code_generator = CppCodeGenerator(

--- a/src/ToolingSharedLibrary/Includes/CmdlineArgumentsParser.h
+++ b/src/ToolingSharedLibrary/Includes/CmdlineArgumentsParser.h
@@ -15,9 +15,9 @@ namespace CmdlineParsingHelpers
 
         bool ShouldDisplayHelp() const {return m_should_display_help; }
         
-        std::string_view EdlFilePath() const { return m_edl_path; }
+        std::filesystem::path EdlFilePath() const { return m_edl_path; }
 
-        std::string_view OutDirectory() const { return m_out_directory; }
+        std::filesystem::path OutDirectory() const { return m_out_directory; }
 
         std::string_view Vtl0ClassName() const { return m_vtl0_class_name; }
 
@@ -29,18 +29,20 @@ namespace CmdlineParsingHelpers
 
         SupportedLanguageKind SupportedLanguage() const { return m_supported_language; }
 
-        std::string_view FlatbufferCompiler() const { return m_flatbuffer_compiler_path; }
+        std::filesystem::path FlatbufferCompiler() const { return m_flatbuffer_compiler_path; }
 
         bool ParseSuccessful() const { return m_parse_successful; }
+
+        std::vector<std::filesystem::path> ImportDirectories() const { return m_import_directories; }
 
     private:
 
         bool ParseArguments(int argc, char* argv[]);
 
         bool m_parse_successful = false;
-        std::string m_edl_path {};
-        std::string m_out_directory {};
-        std::string m_flatbuffer_compiler_path {};
+        std::filesystem::path m_edl_path {};
+        std::filesystem::path m_out_directory {};
+        std::filesystem::path m_flatbuffer_compiler_path {};
         ErrorHandlingKind m_error_handling_kind = ErrorHandlingKind::Unknown;
         VirtualTrustLayerKind m_virtual_trust_layer_kind = VirtualTrustLayerKind::Unknown;
         std::string m_vtl0_class_name{};
@@ -48,5 +50,6 @@ namespace CmdlineParsingHelpers
         bool m_should_display_help = false;
         SupportedLanguageKind m_supported_language = SupportedLanguageKind::Unknown;
         const uint32_t m_required_args = 4;
+        std::vector<std::filesystem::path> m_import_directories;
     };
 }

--- a/src/ToolingSharedLibrary/Includes/CodeGeneration/CodeGeneration.h
+++ b/src/ToolingSharedLibrary/Includes/CodeGeneration/CodeGeneration.h
@@ -7,6 +7,7 @@
 #include <CmdlineParsingHelpers.h>
 #include <CmdlineArgumentsParser.h>
 #include "CodeGenerationHelpers.h"
+#include <Utils\Helpers.h>
 
 using namespace CmdlineParsingHelpers;
 using namespace EdlProcessor;
@@ -104,11 +105,6 @@ namespace CodeGeneration
             const Function& function,
             const FunctionParametersInfo& param_info);
 
-        std::string BuildTypesHeader(
-            std::string_view developer_namespace_name,
-            const std::vector<DeveloperType>& developer_types_insertion_list,
-            const std::vector<DeveloperType>& abi_function_developer_types);
-
         // Intended to be used by in a CallEnclave Win32 function by the
         // abi layer.
         std::string BuildTrustBoundaryFunction(
@@ -116,31 +112,36 @@ namespace CodeGeneration
             std::string_view abi_function_to_call,
             bool is_vtl0_callback,
             const FunctionParametersInfo& param_info);
+
+        std::string BuildTypesHeader(
+            std::string_view developer_namespace_name,
+            const OrderedMap<std::string, DeveloperType>& developer_types_map,
+            std::span<const DeveloperType> abi_function_developer_types);
         
         HostToEnclaveContent BuildHostToEnclaveFunctions(
             std::string_view generated_namespace,
-            std::span<Function> functions);
+            const OrderedMap<std::string, Function>& trusted_functions);
 
         EnclaveToHostContent BuildEnclaveToHostFunctions(
             std::string_view generated_namespace,
             std::string_view generated_class_name,
-            std::span<Function> functions);
+            const OrderedMap<std::string, Function>& untrusted_functions);
 
         std::string BuildVtl1ExportedFunctionsSourcefile(
             std::string_view generated_namespace_name,
-            std::span<Function> developer_functions_to_export);
+            const OrderedMap<std::string, Function>& trusted_functions);
     };
 
     struct CppCodeGenerator
     {
         CppCodeGenerator(
-            const Edl& edl,
+            Edl&& edl,
             const std::filesystem::path& output_path,
             ErrorHandlingKind error_handling,
             VirtualTrustLayerKind trust_layer,
             std::string_view generated_namespace_name,
             std::string_view generated_vtl0_class_name,
-            std::string_view flatbuffer_compiler_path);
+            const std::filesystem::path& flatbuffer_compiler_path);
 
         void Generate();
 

--- a/src/ToolingSharedLibrary/Includes/CodeGeneration/CodeGenerationHelpers.h
+++ b/src/ToolingSharedLibrary/Includes/CodeGeneration/CodeGenerationHelpers.h
@@ -92,18 +92,18 @@ namespace CodeGeneration
     }
 
     inline std::vector<DeveloperType> CreateDeveloperTypesForABIFunctions(
-       std::span<Function> trusted_functions,
-       std::span<Function> untrusted_functions)
+        const OrderedMap<std::string, Function>& trusted_functions,
+        const OrderedMap<std::string, Function>& untrusted_functions)
     {
         std::vector<DeveloperType> dev_types {};
 
-        for (const auto& function : trusted_functions)
+        for (auto& function: trusted_functions.values())
         {
             DeveloperType dev_type = GetDeveloperTypeStructForABI(function);
             dev_types.push_back(dev_type);
         }
 
-        for (const auto& function : untrusted_functions)
+        for (const auto& function : untrusted_functions.values())
         {
             DeveloperType dev_type = GetDeveloperTypeStructForABI(function);
             dev_types.push_back(dev_type);
@@ -299,7 +299,7 @@ namespace CodeGeneration
     
     inline bool ShouldFieldInReturnedStructBeMoved(
         const Declaration& declaration,
-        const std::unordered_map<std::string, DeveloperType>& developer_types)
+        const OrderedMap<std::string, DeveloperType>& developer_types)
     {
         if (declaration.IsPrimitiveType())
         {

--- a/src/ToolingSharedLibrary/Includes/CodeGeneration/Flatbuffers/BuilderHelpers.h
+++ b/src/ToolingSharedLibrary/Includes/CodeGeneration/Flatbuffers/BuilderHelpers.h
@@ -10,7 +10,7 @@ namespace CodeGeneration::Flatbuffers
 {
     std::string GenerateFlatbufferSchema(
         std::string_view developer_namespace_name,
-        const std::vector<DeveloperType>& developer_types_insertion_list,
+        const OrderedMap<std::string, DeveloperType>& developer_types,
         const std::vector<DeveloperType>& abi_function_developer_types);
 
     std::string BuildEnum(const DeveloperType& enum_type);

--- a/src/ToolingSharedLibrary/Includes/Edl/LexicalAnalyzer.h
+++ b/src/ToolingSharedLibrary/Includes/Edl/LexicalAnalyzer.h
@@ -19,6 +19,7 @@ namespace EdlProcessor
     class LexicalAnalyzer
     {
     public:
+        LexicalAnalyzer() = default;
         LexicalAnalyzer(const std::filesystem::path& file_path);
 
         Token GetNextToken();

--- a/src/ToolingSharedLibrary/Includes/Edl/Parser.h
+++ b/src/ToolingSharedLibrary/Includes/Edl/Parser.h
@@ -12,6 +12,7 @@
 #include <unordered_set>
 #include "LexicalAnalyzer.h"
 #include "Utils.h"
+#include <Utils\Helpers.h>
 
 using namespace ErrorHelpers;
 
@@ -23,15 +24,40 @@ namespace EdlProcessor
         Untrusted,
     };
 
+
+    enum class MapKind
+    {
+        DeveloperType,
+        UntrustedFunction,
+        TrustedFunction,
+    };
+
+    enum class ParseStatus
+    {
+        NotSeen,
+        Parsing,
+        Parsed,
+    };
+
+    struct ParsedState
+    {
+        ParseStatus m_status {ParseStatus::NotSeen};
+        Edl m_edl{};
+    };
+
     class EdlParser
     {
     public:
-        EdlParser(const std::filesystem::path& file_path);
+        EdlParser(
+            const std::filesystem::path& file_path, 
+            std::vector<std::filesystem::path> import_directories);
+
         ~EdlParser() = default;
 
         Edl Parse();
-        
+
     private:
+        void ParseInternal(std::unordered_map<std::filesystem::path, ParsedState>& parsed_files);
         void ParseEnum();
         void ParseStruct();
         void ParseFunctions(const FunctionKind& function_kind);
@@ -68,7 +94,9 @@ namespace EdlProcessor
 
         Token PeekAtCurrentToken();
         Token PeekAtNextToken();
-        Edl ParseBody();
+        Edl ParseBody(std::unordered_map<std::filesystem::path, ParsedState>& parsed_files);
+        Edl GenerateEdlObject(std::unordered_map<std::filesystem::path, ParsedState>& parsed_files);
+        void ParseImport(std::unordered_map<std::filesystem::path, ParsedState>& parsed_files);
         Function ParseFunctionDeclaration();
         EdlTypeInfo ParseDeclarationTypeInfo();
         ArrayDimensions ParseArrayDimensions();
@@ -83,18 +111,15 @@ namespace EdlProcessor
 
         std::filesystem::path m_file_path;
         std::filesystem::path m_file_name;
-        std::unique_ptr<LexicalAnalyzer> m_lexical_analyzer {};
+        LexicalAnalyzer m_lexical_analyzer {};
         Token m_cur_token {};
         Token m_next_token {};
         std::uint32_t m_cur_line {};
         std::uint32_t m_cur_column {};
-        std::uint32_t m_abi_function_index {};
-
-        std::vector<DeveloperType> m_developer_types_insertion_order_list {};
-        std::unordered_map<std::string, DeveloperType> m_developer_types;
-        std::unordered_map<std::string, Function> m_trusted_functions_map;
-        std::vector<Function> m_trusted_functions_list {};
-        std::unordered_map<std::string, Function> m_untrusted_functions_map;
-        std::vector<Function> m_untrusted_functions_list {};
+        OrderedMap<std::string, DeveloperType> m_developer_types {};
+        OrderedMap<std::string, Function> m_trusted_functions;
+        OrderedMap<std::string, Function> m_untrusted_functions;
+        std::vector<std::filesystem::path> m_import_directories {};
+        std::vector<std::filesystem::path> m_imported_edl_files {};
     };
 }

--- a/src/ToolingSharedLibrary/Includes/Edl/Structures.h
+++ b/src/ToolingSharedLibrary/Includes/Edl/Structures.h
@@ -9,6 +9,9 @@
 #pragma once
 #include <pch.h>
 #include <unordered_set>
+#include <Utils\Helpers.h>
+
+using namespace Helpers;
 
 namespace EdlProcessor
 {
@@ -420,6 +423,7 @@ namespace EdlProcessor
 
     struct EnumType
     {
+        EnumType() = default;
         EnumType(std::string name, std::uint64_t position)
             : m_name(name), m_declared_position(position)
         {
@@ -461,9 +465,10 @@ namespace EdlProcessor
         std::string m_name;
         EdlTypeKind m_type_kind;
         std::vector<Declaration> m_fields;
-        std::unordered_map<std::string, EnumType> m_items;
+        OrderedMap<std::string, EnumType> m_items;
         bool m_contains_inner_pointer {};
         bool m_contains_container_type{};
+        std::filesystem::path m_parent_file{};
     };
 
     struct Function
@@ -500,6 +505,7 @@ namespace EdlProcessor
         std::string abi_m_name {};
         Declaration m_return_info {DeclarationParentKind::Function};
         std::vector<Declaration> m_parameters{};
+        std::filesystem::path m_parent_file{};
     private:
         std::string m_signature{};
     };
@@ -507,11 +513,8 @@ namespace EdlProcessor
     struct Edl
     {
         std::string m_name{};
-        std::unordered_map<std::string, DeveloperType> m_developer_types{};
-        std::vector<DeveloperType> m_developer_types_insertion_order_list {};
-        std::unordered_map<std::string, Function> m_trusted_functions_map{};
-        std::vector<Function> m_trusted_functions_list {};
-        std::unordered_map<std::string, Function> m_untrusted_functions_map{};
-        std::vector<Function> m_untrusted_functions_list {};
+        OrderedMap<std::string, DeveloperType> m_developer_types;
+        OrderedMap<std::string, Function> m_trusted_functions;
+        OrderedMap<std::string, Function> m_untrusted_functions;
     };
 }

--- a/src/ToolingSharedLibrary/Includes/Edl/Utils.h
+++ b/src/ToolingSharedLibrary/Includes/Edl/Utils.h
@@ -38,6 +38,7 @@ namespace EdlProcessor
     constexpr const char* EDL_UNTRUSTED_KEYWORD = "untrusted";
     constexpr const char* EDL_ENUM_KEYWORD = "enum";
     constexpr const char* EDL_STRUCT_KEYWORD = "struct";
+    constexpr const char* EDL_IMPORT_KEYWORD = "import";
     constexpr const std::uint32_t MINIMUM_HEX_LENGTH = 3;
     constexpr const std::uint32_t HEX_PREFIX_LENGTH = 2;
     constexpr const char* HEX_PREFIX[HEX_PREFIX_LENGTH] = { "0x", "0X"};

--- a/src/ToolingSharedLibrary/Includes/ErrorHelpers.h
+++ b/src/ToolingSharedLibrary/Includes/ErrorHelpers.h
@@ -21,6 +21,7 @@ namespace ErrorHelpers
     enum class ErrorId : std::uint32_t
     {
         Success = 0,
+        Unknown,
         LanguageNoMoreArgs,
         UnsupportedLanguage,
         EdlNoMoreArgs,
@@ -82,6 +83,13 @@ namespace ErrorHelpers
         EdlVectorNameIdentifierNotFound,
         EdlVectorDoesNotStartWithArrowBracket,
         EdlTypeInVectorMustBePreviouslyDefined,
+        ImportDirectoriesNoMoreArgs,
+        ImportDirectoryDoesNotExist,
+        ImportedEdlFileDoesNotExist,
+        DuplicateDevTypeInImportFile,
+        DuplicateTrustedFunctionInImportFile,
+        DuplicateUntrustedFunctionInImportFile,
+        ImportCycleFound,
     };
 
     struct ErrorIdHash
@@ -111,6 +119,13 @@ namespace ErrorHelpers
         { ErrorId::FlatbufferCompilerNoMoreArgs,"Unable to find flatbuffers compiler file path. No more commandline arguments available to find the path to the flatbuffer compiler file." },
         { ErrorId::FlatbufferCompilerDoesNotExist,"The path to the provided flatbuffer compiler file '{}' does not exist." },
         { ErrorId::NotAFile, "The path '{}' must be to a valid file." },
+        { ErrorId::ImportDirectoriesNoMoreArgs,"Unable to find import directiories. No more commandline arguments available to find edl import directories." },
+        { ErrorId::ImportDirectoryDoesNotExist,"The import directory '{}' does not exist or is not a directory." },
+        { ErrorId::ImportedEdlFileDoesNotExist, "import file '{}' was not found for '{}'. Check that the .edl file exists in your import directories." },
+        { ErrorId::DuplicateDevTypeInImportFile, "Found duplicate type '{}' in import file '{}' when parsing '{}'. Types must only be defined once per .edl file." },
+        { ErrorId::DuplicateTrustedFunctionInImportFile, "Found duplicate trusted function '{}' in import file '{}' when parsing '{}'. Functions must only be defined once per scope (trusted/untrusted), per .edl file." },
+        { ErrorId::DuplicateUntrustedFunctionInImportFile, "Found duplicate untrusted function '{}' in import file '{}' when parsing '{}'. Functions must only be defined once per scope (trusted/untrusted), per .edl file." },
+        { ErrorId::ImportCycleFound, "Import cycle found when attempting to import '{}' into '{}'." },
 
         // Edl file lexical analysis errors
         { ErrorId::EdlCommentEndingNotFound, "EOF while looking for '*/' to match the '/*'" },

--- a/src/ToolingSharedLibrary/Includes/Exceptions.h
+++ b/src/ToolingSharedLibrary/Includes/Exceptions.h
@@ -22,6 +22,7 @@ namespace ToolingExceptions
         {
             m_message = std::format("{}: line: {}, column: {}\n", file_name.generic_string(), line_num, column_num);
             m_message += GetErrorMessageById(id, std::forward<Args>(args)...);
+            m_id = id;
         }
 
         template<typename... Args>
@@ -30,6 +31,7 @@ namespace ToolingExceptions
             const std::filesystem::path& file_name)
         {
             m_message = GetErrorMessageById(id, file_name.generic_string());
+            m_id = id;
         }
 
         const char* what() const noexcept override
@@ -37,8 +39,11 @@ namespace ToolingExceptions
             return m_message.c_str();
         }
 
+        ErrorId GetErrorId() { return  m_id; }
+
     private:
         std::string m_message;
+        ErrorId m_id {ErrorId::Unknown};
     };
 
     class CodeGenerationException : public std::exception

--- a/src/ToolingSharedLibrary/Includes/Utils/Helpers.h
+++ b/src/ToolingSharedLibrary/Includes/Utils/Helpers.h
@@ -1,0 +1,120 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+#include <pch.h>
+#include <span>
+#include <ranges>
+
+namespace Helpers
+{
+    // Simple OrderedMap class to maintain insertion order and fast lookup
+    template<typename Key, typename Value>
+    class OrderedMap 
+    {
+        public:
+            Value& at(const Key& key) { return m_map.at(key); }
+            const Value& at(const Key& key) const { return m_map.at(key); }
+            auto find(const Key& key) { return m_map.find(key); }
+            auto find(const Key& key) const { return m_map.find(key); }
+            std::span<const Key> keys() const { return m_keys; }
+            size_t size() const { return m_map.size(); }
+
+            // Technically if this was a true orderedmap doing begin() should return [key in order, value in order]
+            // not the unordered_map version. However we don't need this for our use cases. We just need this classes 
+            // keys() and values() methods to return their data in insertion order.
+            auto begin() const { return m_map.begin(); }
+            auto end() const { return m_map.end(); }
+            auto begin() { return m_map.begin(); }
+            auto end() { return m_map.end(); }
+
+            const Value& operator[](const Key& key) const { return m_map.at(key); }
+            bool contains(const Key& key) const { return m_map.contains(key); }
+            bool empty() const { return m_map.empty(); }
+            void clear()
+            {
+                m_map.clear();
+                m_keys.clear();
+            }
+
+            Value& operator[](const Key& key)
+            {
+                if (!contains(key))
+                {
+                    m_keys.push_back(key);
+                }
+
+                return m_map[key];
+            }
+
+
+            void insert(const Key key, const Value& value)
+            {
+                if (!contains(key))
+                {
+                    m_keys.push_back(key);
+                }
+
+                m_map[key] = value;
+            }
+
+            void insert_front(const Key key, const Value& value)
+            {
+                if (!contains(key))
+                {
+                    m_keys.insert(m_keys.begin(), key);
+                }
+
+                m_map[key] = value;
+            }
+
+            // Merge another OrderedMap into this one, preserving order and uniqueness
+            void merge(const OrderedMap& other)
+            {
+                for (const auto& key : other.m_keys)
+                {
+                    if (!contains(key))
+                    {
+                        insert(key, other.m_map.at(key));
+                    }
+                }
+            }
+
+            // Merge another OrderedMap into this one with a custom conflict resolver
+            template<typename ConflictResolver>
+            void merge(const OrderedMap& other, ConflictResolver resolver)
+            {
+                for (const auto& key : other.m_keys)
+                {
+                    if (contains(key))
+                    {
+                        resolver(key, other.m_map.at(key), m_map.at(key));
+                    }
+                    else
+                    {
+                        insert(key, other.m_map.at(key));
+                    }
+                }
+            }
+
+            auto values() const
+            {
+                return m_keys | std::views::transform([this] (const std::string& key) -> const Value&
+                {
+                    return m_map.at(key);
+                });
+            }
+
+            auto values()
+            {
+                return m_keys | std::views::transform([this] (const std::string& key) -> Value&
+                {
+                    return m_map.at(key);
+                });
+            }
+
+        private:
+            std::unordered_map<Key, Value> m_map;
+            std::vector<Key> m_keys; // Keys are kept in insertion order.
+    };
+}

--- a/src/ToolingSharedLibrary/ToolingExecutable/CmdlineArgumentsParser.cpp
+++ b/src/ToolingSharedLibrary/ToolingExecutable/CmdlineArgumentsParser.cpp
@@ -74,6 +74,11 @@ bool CmdlineArgumentsParser::ParseArguments(int argc, char* argv[])
             m_vtl0_class_name = argv[++i];
             args_found++;
         }
+        else if (arg == "--ImportDirectories")
+        {
+            CHECK_SUCCESS(GetImportDirectoriesFromArgs(++i, argv, argc, m_import_directories));
+            args_found++;
+        }
         else if (arg == "--FlatbuffersCompilerPath")
         {
             CHECK_SUCCESS(GetFlatbuffersCompilerPathFromArgs(++i, argv, argc, m_flatbuffer_compiler_path));
@@ -85,6 +90,9 @@ bool CmdlineArgumentsParser::ParseArguments(int argc, char* argv[])
             return false;
         }
     }
+
+    // Add parent directory by default
+    m_import_directories.push_back(m_edl_path.parent_path());
 
     if (args_found < m_required_args)
     {

--- a/src/ToolingSharedLibrary/ToolingExecutable/CodeGeneration/CppCodeBuilder.cpp
+++ b/src/ToolingSharedLibrary/ToolingExecutable/CodeGeneration/CppCodeBuilder.cpp
@@ -18,14 +18,14 @@ namespace CodeGeneration
 {
     std::string CppCodeBuilder::BuildTypesHeader(
         std::string_view developer_namespace_name,
-        const std::vector<DeveloperType>& developer_types_insertion_list,
-        const std::vector<DeveloperType>& abi_function_developer_types)
+        const OrderedMap<std::string, DeveloperType>& developer_types_map,
+        std::span<const DeveloperType> abi_function_developer_types)
     {
         std::ostringstream types_header {};
         std::ostringstream enums_definitions {};
         std::ostringstream struct_declarations {};
 
-        for (auto& type : developer_types_insertion_list)
+        for (auto& type : developer_types_map.values())
         {
             if (type.IsEdlType(EdlTypeKind::Enum) || type.IsEdlType(EdlTypeKind::AnonymousEnum))
             {
@@ -41,7 +41,7 @@ namespace CodeGeneration
         types_header << enums_definitions.str();
         std::ostringstream struct_metadata {};
 
-        for (auto& type : developer_types_insertion_list)
+        for (auto& type : developer_types_map.values())
         {
             if (type.IsEdlType(EdlTypeKind::Struct))
             {
@@ -102,23 +102,23 @@ namespace CodeGeneration
 
         auto [enum_header, enum_body, enum_footer] = BuildStartOfDefinition(EDL_ENUM_KEYWORD, enum_name);
 
-        for (auto& [enum_value_name, enum_value] : developer_types.m_items)
+        for (auto& enum_value : developer_types.m_items.values())
         {
             if (enum_value.m_value)
             {
                 // Value was the enum name for a value within the anonymous enum.
                 Token value_token = enum_value.m_value.value();
-                enum_body << std::format("{}{} = {},\n", c_four_spaces, enum_value_name, value_token.ToString());
+                enum_body << std::format("{}{} = {},\n", c_four_spaces, enum_value.m_name, value_token.ToString());
             }
             else if (enum_value.m_is_hex)
             {
                 auto hex_value = uint64_to_hex(enum_value.m_declared_position);
-                enum_body << std::format("{}{} = {},\n", c_four_spaces, enum_value_name, hex_value);
+                enum_body << std::format("{}{} = {},\n", c_four_spaces, enum_value.m_name, hex_value);
             }
             else
             {
                 auto decimal_value = uint64_to_decimal(enum_value.m_declared_position);
-                enum_body << std::format("{}{} = {},\n", c_four_spaces, enum_value_name, decimal_value);
+                enum_body << std::format("{}{} = {},\n", c_four_spaces, enum_value.m_name, decimal_value);
             }
         }
 
@@ -482,14 +482,14 @@ namespace CodeGeneration
 
     CppCodeBuilder::HostToEnclaveContent CppCodeBuilder::BuildHostToEnclaveFunctions(
         std::string_view generated_namespace,
-        std::span<Function> functions)
+        const OrderedMap<std::string, Function>& trusted_functions)
     {
         std::ostringstream vtl1_abi_boundary_functions {};
         std::ostringstream vtl1_abi_impl_functions {};
         std::ostringstream vtl1_trusted_function_declarations {};
         std::ostringstream vtl0_stubs_for_vtl1_trusted_functions {};
 
-        for (auto& function : functions)
+        for (auto& function : trusted_functions.values())
         {
             auto param_info = GetInformationAboutParameters(function);
             auto vtl1_exported_func_name = std::format(c_generated_stub_name, function.abi_m_name);
@@ -553,10 +553,10 @@ namespace CodeGeneration
     CppCodeBuilder::EnclaveToHostContent CppCodeBuilder::BuildEnclaveToHostFunctions(
         std::string_view generated_namespace,
         std::string_view generated_class_name,
-        std::span<Function> functions)
+        const OrderedMap<std::string, Function>& untrusted_functions)
     {
-        size_t number_of_functions = functions.size();
-        size_t number_of_functions_plus_allocators = functions.size() + c_number_of_abi_callbacks;
+        size_t number_of_functions = untrusted_functions.size();
+        size_t number_of_functions_plus_allocators = untrusted_functions.size() + c_number_of_abi_callbacks;
         std::ostringstream vtl1_callback_functions {};
         std::ostringstream vtl0_abi_boundary_functions {};
         std::ostringstream vtl0_abi_impl_callback_functions {};
@@ -573,7 +573,7 @@ namespace CodeGeneration
         vtl0_class_method_names << c_allocate_memory_callback_to_name.data();
         vtl0_class_method_names << c_deallocate_memory_callback_to_name.data();
 
-        for (auto& function : functions)
+        for (const auto& function : untrusted_functions.values())
         {
             auto param_info = GetInformationAboutParameters(function);
 
@@ -654,12 +654,12 @@ namespace CodeGeneration
 
     std::string CppCodeBuilder::BuildVtl1ExportedFunctionsSourcefile(
         std::string_view generated_namespace_name,
-        std::span<Function> developer_functions_to_export)
+        const OrderedMap<std::string, Function>& trusted_functions)
     {
         std::ostringstream exported_definitions {};
         std::ostringstream pragma_link_statements {};
 
-        for (auto& function : developer_functions_to_export)
+        for (const auto& function : trusted_functions.values())
         {
             auto generated_func_name = std::format(c_generated_stub_name_no_quotes, function.abi_m_name);
             exported_definitions << std::format(

--- a/src/ToolingSharedLibrary/ToolingExecutable/CodeGeneration/CppCodeGenerator.cpp
+++ b/src/ToolingSharedLibrary/ToolingExecutable/CodeGeneration/CppCodeGenerator.cpp
@@ -16,14 +16,14 @@ using namespace CodeGeneration::Flatbuffers;
 namespace CodeGeneration
 {
     CppCodeGenerator::CppCodeGenerator(
-        const Edl& edl,
+        Edl&& edl,
         const std::filesystem::path& output_path,
         ErrorHandlingKind error_handling,
         VirtualTrustLayerKind trust_layer,
         std::string_view generated_namespace_name,
         std::string_view generated_vtl0_class_name,
-        std::string_view flatbuffer_compiler_path)
-        :   m_edl(edl),
+        const std::filesystem::path& flatbuffer_compiler_path)
+        :   m_edl(std::move(edl)),
             m_output_folder_path(output_path),
             m_error_handling(error_handling),
             m_virtual_trust_layer_kind(trust_layer),
@@ -63,32 +63,33 @@ namespace CodeGeneration
         auto enclave_headers_location = m_output_folder_path / enclave_headers_output;
         auto hostapp_headers_location = m_output_folder_path / hostapp_headers_output;
 
+        // Use OrderedMap directly
         auto abi_function_developer_types = CreateDeveloperTypesForABIFunctions(
-            m_edl.m_trusted_functions_list,
-            m_edl.m_untrusted_functions_list);
+            m_edl.m_trusted_functions,
+            m_edl.m_untrusted_functions);
 
         // Create developer types. This is shared between
         // the HostApp and the enclave.
         std::string enclave_types_header = BuildTypesHeader(
             m_generated_namespace_name,
-            m_edl.m_developer_types_insertion_order_list,
-            abi_function_developer_types);
+            m_edl.m_developer_types,
+            std::span<const DeveloperType>(abi_function_developer_types));
 
         auto flatbuffer_schema = GenerateFlatbufferSchema(
             m_generated_namespace_name,
-            m_edl.m_developer_types_insertion_order_list,
+            m_edl.m_developer_types,
             abi_function_developer_types);
 
         // Process content from the trusted content.
         auto host_to_enclave_content = BuildHostToEnclaveFunctions(
             m_generated_namespace_name,
-            m_edl.m_trusted_functions_list);
+            m_edl.m_trusted_functions);
 
         // Process the content from the untrusted functions
         auto enclave_to_host_content = BuildEnclaveToHostFunctions(
             m_generated_namespace_name, 
             m_generated_vtl0_class_name,
-            m_edl.m_untrusted_functions_list);
+            m_edl.m_untrusted_functions);
 
         std::filesystem::path save_location{};
         CppCodeBuilder::HeaderKind header_kind{};
@@ -100,7 +101,7 @@ namespace CodeGeneration
 
             std::string exported_definitions_source = BuildVtl1ExportedFunctionsSourcefile(
                 m_generated_namespace_name,
-                m_edl.m_trusted_functions_list);
+                m_edl.m_trusted_functions);
 
             SaveFileToOutputFolder(
                 c_enclave_exports_source,

--- a/src/ToolingSharedLibrary/ToolingExecutable/CodeGeneration/Flatbuffers/BuilderHelpers.cpp
+++ b/src/ToolingSharedLibrary/ToolingExecutable/CodeGeneration/Flatbuffers/BuilderHelpers.cpp
@@ -20,14 +20,14 @@ namespace CodeGeneration::Flatbuffers
 
     std::string GenerateFlatbufferSchema(
         std::string_view developer_namespace_name,
-        const std::vector<DeveloperType>& developer_types_insertion_list,
+        const OrderedMap<std::string, DeveloperType>& developer_types,
         const std::vector<DeveloperType>& abi_function_developer_types)
     {
         std::ostringstream schema {};
         auto schema_namespace = std::format(c_flatbuffer_namespace, developer_namespace_name);
         schema << c_autogen_header_string << schema_namespace;
 
-        for (auto& dev_type : developer_types_insertion_list)
+        for (const auto& dev_type : developer_types.values())
         {
             if (dev_type.IsEdlType(EdlTypeKind::Enum))
             {
@@ -59,22 +59,22 @@ namespace CodeGeneration::Flatbuffers
     {
         std::ostringstream enum_body {};
 
-        for (auto& [enum_value_name, enum_value] : enum_type.m_items)
+        for (auto& enum_value : enum_type.m_items.values())
         {
             if (enum_value.m_value)
             {
                 // Raw value will only ever be an numeric value.
                 Token value_token = enum_value.m_value.value();
-                enum_body << std::format("    {} = {},\n", enum_value_name, value_token.ToString());
+                enum_body << std::format("    {} = {},\n", enum_value.m_name, value_token.ToString());
             }
             else
             {
-                enum_body << std::format("    {} = {},\n", enum_value_name, enum_value.m_declared_position);
+                enum_body << std::format("    {} = {},\n", enum_value.m_name, enum_value.m_declared_position);
             }
 
             if (enum_value.m_is_default_value)
             {
-                g_enum_data.emplace(enum_type.m_name, enum_value_name);
+                g_enum_data.emplace(enum_type.m_name, enum_value.m_name);
             }
         }
 

--- a/src/ToolingSharedLibrary/ToolingExecutable/Edl/Parser.cpp
+++ b/src/ToolingSharedLibrary/ToolingExecutable/Edl/Parser.cpp
@@ -16,8 +16,14 @@ namespace EdlProcessor
 {
     static const std::uint32_t c_max_number_of_pointers = 1;
 
-    EdlParser::EdlParser(const std::filesystem::path& file_path)
-        : m_file_path(file_path), m_file_name(m_file_path.filename().replace_extension()), m_cur_line(1), m_cur_column(1)
+    EdlParser::EdlParser(
+        const std::filesystem::path& file_path, 
+        std::vector<std::filesystem::path> import_directories) :
+            m_import_directories(std::move(import_directories)),
+            m_file_path(file_path),
+            m_file_name(m_file_path.filename().replace_extension()),
+            m_cur_line(1),
+            m_cur_column(1)
     {
     }
 
@@ -35,7 +41,7 @@ namespace EdlProcessor
     {
         Token token = m_cur_token;
         m_cur_token = m_next_token;
-        m_next_token = m_lexical_analyzer->GetNextToken();
+        m_next_token = m_lexical_analyzer.GetNextToken();
         m_cur_line = token.m_line_number;
         m_cur_column = token.m_column_number;
         return token;
@@ -118,34 +124,139 @@ namespace EdlProcessor
                 struct_or_function_name);
         }
     }
-
     Edl EdlParser::Parse()
+    {
+        std::unordered_map<std::filesystem::path, ParsedState> parsed_files;
+        ParseInternal(parsed_files);
+        return parsed_files[m_file_path].m_edl;
+    }
+    
+    void EdlParser::ParseInternal(std::unordered_map<std::filesystem::path, ParsedState>& parsed_files)
     {
         std::string status = std::format("Processing {}", m_file_name.generic_string());
         PrintStatus(Status::Info, status);
+        parsed_files[m_file_path] = { ParseStatus::Parsing, m_file_name.generic_string() };
 
         // Start LexicalAnalyzer so we can walk through .edl file.
-        m_lexical_analyzer = std::make_unique<LexicalAnalyzer>(m_file_path);
-        m_cur_token = m_lexical_analyzer->GetNextToken();
-        m_next_token = m_lexical_analyzer->GetNextToken();
+        m_lexical_analyzer = LexicalAnalyzer{m_file_path};
+        m_cur_token = m_lexical_analyzer.GetNextToken();
+        m_next_token = m_lexical_analyzer.GetNextToken();
 
         ThrowIfExpectedTokenNotNext(EDL_ENCLAVE_KEYWORD);
         ThrowIfExpectedTokenNotNext(LEFT_CURLY_BRACKET);
-        Edl edl = ParseBody();
+        Edl edl = ParseBody(parsed_files);
         edl.m_name = m_file_name.generic_string();
         ThrowIfExpectedTokenNotNext(RIGHT_CURLY_BRACKET);
 
         status = std::format("Completed parsing {} successfully", m_file_name.generic_string());
         PrintStatus(Status::Info, status);
-
-        return edl;
+        parsed_files[m_file_path].m_status = ParseStatus::Parsed;
+        parsed_files[m_file_path].m_edl = std::move(edl);
     }
 
-    Edl EdlParser::ParseBody()
+    void MergeEdl(
+        Edl& src_edl, 
+        Edl& dest_edl,
+        std::uint32_t line_num,
+        std::uint32_t column_num)
+    {
+        auto make_conflict_checker = [&](MapKind map_kind) 
+        {
+            return [&, map_kind](const std::string& key, const auto& src_value, const auto& dest_value) 
+            {    
+                // Same source file, no conflict
+                if (src_value.m_parent_file == dest_value.m_parent_file) 
+                {
+                    return;
+                }
+
+                ErrorId error_id = ErrorId::DuplicateDevTypeInImportFile;
+
+                if (map_kind == MapKind::TrustedFunction)
+                {
+                    error_id = ErrorId::DuplicateTrustedFunctionInImportFile;
+                } else if (map_kind == MapKind::UntrustedFunction)
+                {
+                    error_id = ErrorId::DuplicateUntrustedFunctionInImportFile;
+                }
+
+                throw EdlAnalysisException(
+                    error_id,
+                    src_edl.m_name,
+                    line_num,
+                    column_num,
+                    src_value.m_name,
+                    dest_edl.m_name,
+                    src_edl.m_name);
+            };
+        };
+
+        // Merge using OrderedMap's merge function with conflict resolution lambdas
+        dest_edl.m_developer_types.merge(
+            src_edl.m_developer_types, 
+            [&](const std::string& key, const auto& src_value, const auto& dest_value) 
+            {
+                if (key == EDL_ANONYMOUS_ENUM_KEYWORD)
+                {
+                    // Handle anonymous enum merging. We don't want to throw if multiple edl files contain the
+                    // anonymous enum. We'll just merge them together.
+                    auto imported_enum = src_edl.m_developer_types.at(EDL_ANONYMOUS_ENUM_KEYWORD);
+                    auto dest_enum = dest_edl.m_developer_types.find(EDL_ANONYMOUS_ENUM_KEYWORD);
+                    
+                    if (dest_enum != dest_edl.m_developer_types.end())
+                    {
+                        // if it exists in the dest_edl, values in the dest_edl version will take precedence.
+                        dest_enum->second.m_items.merge(imported_enum.m_items);
+                    }
+                    else
+                    {
+                        dest_edl.m_developer_types.insert_front(EDL_ANONYMOUS_ENUM_KEYWORD, imported_enum);
+                    }
+                }
+                else
+                {
+                    make_conflict_checker(MapKind::DeveloperType)(key, src_value, dest_value);
+                }
+            });
+
+        dest_edl.m_trusted_functions.merge(src_edl.m_trusted_functions, make_conflict_checker(MapKind::TrustedFunction));
+
+        dest_edl.m_untrusted_functions.merge(src_edl.m_untrusted_functions, make_conflict_checker(MapKind::UntrustedFunction));
+    }
+
+    Edl EdlParser::GenerateEdlObject(std::unordered_map<std::filesystem::path, ParsedState>& parsed_files)
+    {
+        Edl cur_file_edl
+        { 
+            m_file_name.generic_string(),
+            m_developer_types,
+            m_trusted_functions,
+            m_untrusted_functions,
+        };
+
+        // Merge imported edl object data into the current edl object.
+        if (!m_imported_edl_files.empty())
+        {
+            Edl edl_with_imported_data;
+            edl_with_imported_data.m_name = cur_file_edl.m_name;
+
+            for (auto& edl_file : m_imported_edl_files)
+            {
+                auto& imported_edl = parsed_files.at(edl_file).m_edl;
+                MergeEdl(imported_edl, edl_with_imported_data, m_cur_line, m_cur_column);
+            }
+
+            MergeEdl(cur_file_edl, edl_with_imported_data, m_cur_line, m_cur_column);
+            return edl_with_imported_data;
+        }
+
+        return cur_file_edl;
+    }
+
+    Edl EdlParser::ParseBody(std::unordered_map<std::filesystem::path, ParsedState>& parsed_files)
     {
         while (PeekAtCurrentToken() != RIGHT_CURLY_BRACKET && PeekAtCurrentToken() != END_OF_FILE_CHARACTER)
         {
-            
             Token token = GetCurrentTokenAndMoveToNextToken();
 
             if (token == EDL_TRUSTED_KEYWORD)
@@ -164,6 +275,10 @@ namespace EdlProcessor
             {
                 ParseStruct();
             }
+            else if (token == EDL_IMPORT_KEYWORD)
+            {
+                ParseImport(parsed_files);
+            }
             else
             {
                 throw EdlAnalysisException(
@@ -173,26 +288,18 @@ namespace EdlProcessor
                     token.m_column_number,
                     token.ToString());
             }
-            
         }
 
         PerformFinalValidations();
         UpdateDeveloperTypeMetadata();
 
-        return Edl{
-            m_file_name.generic_string(),
-            m_developer_types,
-            m_developer_types_insertion_order_list,
-            m_trusted_functions_map,
-            m_trusted_functions_list,
-            m_untrusted_functions_map,
-            m_untrusted_functions_list};
+        return GenerateEdlObject(parsed_files);
     }
 
     void EdlParser::UpdateDeveloperTypeMetadata()
     {
-        for (auto& [name, developer_type] : m_developer_types)
-        {
+        for (auto& developer_type : m_developer_types.values())
+        {           
             // Update developer type to take into account struct fields where the type may contain
             // a container type or a pointer.
             for (auto& field : developer_type.m_fields)
@@ -207,16 +314,19 @@ namespace EdlProcessor
                     continue;
                 }
 
-                const auto& struct_field = m_developer_types.at(field.m_edl_type_info.m_name);
-
-                if (struct_field.m_contains_inner_pointer)
+                if (m_developer_types.contains(field.m_edl_type_info.m_name))
                 {
-                    developer_type.m_contains_inner_pointer = true;
-                }
+                    const auto& struct_field = m_developer_types.at(field.m_edl_type_info.m_name);
 
-                if (struct_field.m_contains_container_type)
-                {
-                    developer_type.m_contains_container_type = true;
+                    if (struct_field.m_contains_inner_pointer)
+                    {
+                        developer_type.m_contains_inner_pointer = true;
+                    }
+
+                    if (struct_field.m_contains_container_type)
+                    {
+                        developer_type.m_contains_container_type = true;
+                    }
                 }
             }
         }
@@ -224,8 +334,7 @@ namespace EdlProcessor
 
     void EdlParser::AddDeveloperType(const DeveloperType& new_type)
     {
-        m_developer_types.emplace(new_type.m_name, new_type);
-        m_developer_types_insertion_order_list.push_back(new_type);
+        m_developer_types.insert(new_type.m_name, new_type);
     }
 
     void EdlParser::ParseEnum()
@@ -341,15 +450,14 @@ namespace EdlProcessor
                     value_name);
             }
 
-            m_developer_types[type_name].m_items.emplace(value_name, enum_type);
+            m_developer_types[type_name].m_items.insert(value_name, enum_type);
             cur_enum_value_position++;
             is_default_value = false;
         }
 
         ThrowIfExpectedTokenNotNext(RIGHT_CURLY_BRACKET);
         ThrowIfExpectedTokenNotNext(SEMI_COLON);
-
-        m_developer_types_insertion_order_list.push_back(m_developer_types[type_name]);
+        m_developer_types[type_name].m_parent_file = m_file_path;
     }
 
     void EdlParser::ParseThroughFieldsOrParameterList(
@@ -423,28 +531,25 @@ namespace EdlProcessor
 
         ThrowIfExpectedTokenNotNext(RIGHT_CURLY_BRACKET);
         ThrowIfExpectedTokenNotNext(SEMI_COLON);   
-        
+        new_struct_type.m_parent_file = m_file_path;
         AddDeveloperType(new_struct_type);
     }
 
     void EdlParser::ParseFunctions(const FunctionKind& function_kind)
     {
         ThrowIfExpectedTokenNotNext(LEFT_CURLY_BRACKET);
-        std::reference_wrapper<std::unordered_map<std::string, Function>> func_map = m_trusted_functions_map;
-        std::reference_wrapper<std::vector<Function>> func_list = m_trusted_functions_list;
-
-        if (function_kind == FunctionKind::Untrusted)
-        {
-            func_map = m_untrusted_functions_map;
-            func_list = m_untrusted_functions_list;
-        }
+        OrderedMap<std::string, Function>& func_map = 
+            (function_kind == FunctionKind::Untrusted) 
+            ? m_untrusted_functions
+            : m_trusted_functions;
 
         while (PeekAtCurrentToken() != RIGHT_CURLY_BRACKET)
         {            
             Function parsed_function = ParseFunctionDeclaration();
             std::string function_signature = parsed_function.GetDeclarationSignature();
+            parsed_function.m_parent_file = m_file_path;
 
-            if (func_map.get().contains(function_signature))
+            if (func_map.contains(function_signature))
             {
                 throw EdlAnalysisException(
                     ErrorId::EdlDuplicateFunctionDeclaration,
@@ -457,10 +562,9 @@ namespace EdlProcessor
             // Since we allow developer functions to contain the same name but with different
             // parameters, we need to make sure the non developer facing functions are unique
             // in our abi layer. So we append a number to the function name.
+            static std::size_t m_abi_function_index{};
             parsed_function.abi_m_name = std::format("{}_{}", parsed_function.m_name, m_abi_function_index++);
-
-            func_map.get().emplace(function_signature, parsed_function);
-            func_list.get().push_back(parsed_function);
+            func_map.insert(function_signature, parsed_function);
         }
 
         ThrowIfExpectedTokenNotNext(RIGHT_CURLY_BRACKET);
@@ -949,19 +1053,19 @@ namespace EdlProcessor
     {
         // now that we've finished parsing the function declarations and structs 
         // Make sure the size/count attributes are validated.
-        for (const auto& [function_name, function] : m_trusted_functions_map)
+        for (auto& function : m_trusted_functions.values())
         {
-            ValidateSizeAndCountAttributeDeclarations(function_name, function.m_parameters);
+            ValidateSizeAndCountAttributeDeclarations(function.m_name, function.m_parameters);
         }
 
-        for (const auto& [function_name, function] : m_untrusted_functions_map)
+        for (auto& function : m_untrusted_functions.values())
         {
-            ValidateSizeAndCountAttributeDeclarations(function_name, function.m_parameters);
+            ValidateSizeAndCountAttributeDeclarations(function.m_name, function.m_parameters);
         }
 
-        for (const auto& [name, developer_type] : m_developer_types)
+        for (auto& developer_type : m_developer_types.values())
         {
-            ValidateSizeAndCountAttributeDeclarations(name, developer_type.m_fields);
+            ValidateSizeAndCountAttributeDeclarations(developer_type.m_name, developer_type.m_fields);
         }
     }
 
@@ -1042,4 +1146,95 @@ namespace EdlProcessor
             }
         }
     }
+
+    std::string RemoveOuterQuotes(const std::string& input)
+    {
+        if (input.size() >= 2 && input.front() == '"' && input.back() == '"')
+        {
+            return input.substr(1, input.size() - 2);
+        }
+
+        return input; // Return unchanged if no outer quotes
+    }
+
+    bool FileExistsAndIsEdl(std::filesystem::path& file)
+    {
+        return std::filesystem::exists(file) && file.extension() == L".edl";
+    }
+
+    void EdlParser::ParseImport(std::unordered_map<std::filesystem::path, ParsedState>& parsed_files)
+    {
+        auto import_file_token = GetCurrentTokenAndMoveToNextToken();
+        std::filesystem::path import_file = RemoveOuterQuotes(import_file_token.ToString());
+        std::filesystem::path full_file_path{};
+
+        // first check if this is an absolute path
+        if (import_file.is_absolute() && FileExistsAndIsEdl(import_file))
+        {
+            full_file_path = std::move(import_file);
+        }
+        else
+        {
+            for (auto& directory : m_import_directories)
+            {
+                auto potential_file = directory / import_file;
+
+                if (FileExistsAndIsEdl(potential_file))
+                {
+                    full_file_path = std::move(potential_file);
+                    break;
+                }
+            }
+        }
+
+        auto importer = m_file_path.filename();
+
+        if (full_file_path.empty())
+        {
+            throw EdlAnalysisException(
+                ErrorId::ImportedEdlFileDoesNotExist,
+                m_file_name,
+                m_cur_line,
+                m_cur_column,
+                import_file.generic_string(),
+                importer.generic_string());
+        }
+
+        ThrowIfExpectedTokenNotNext(SEMI_COLON);
+
+        auto find_import_file = std::find(m_imported_edl_files.begin(), m_imported_edl_files.end(), full_file_path);
+
+        if (find_import_file == m_imported_edl_files.end())
+        {
+            m_imported_edl_files.push_back(full_file_path);
+        }
+
+        auto parse_data = parsed_files.find(full_file_path);
+
+        if (parse_data != parsed_files.end())
+        {
+            auto& parse_state = parse_data->second;
+
+            if (parse_state.m_status == ParseStatus::Parsing)
+            {
+                throw EdlAnalysisException(
+                    ErrorId::ImportCycleFound,
+                    m_file_name,
+                    m_cur_line,
+                    m_cur_column,
+                    import_file.generic_string(),
+                    importer.generic_string());
+            }
+            else if (parse_state.m_status == ParseStatus::Parsed)
+            {
+                // Ignore duplicate imports. As long as we've parsed
+                // the imported file at least once we're ok.
+                return;
+            }
+        }
+
+        EdlParser parser(full_file_path, m_import_directories);
+        parser.ParseInternal(parsed_files);
+    }
+
 }

--- a/src/ToolingSharedLibrary/ToolingSharedLibrary.vcxproj
+++ b/src/ToolingSharedLibrary/ToolingSharedLibrary.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM64">
@@ -191,6 +191,7 @@
     <ClInclude Include="Includes\CmdlineParsingHelpers.h" />
     <ClInclude Include="Includes\CodeGeneration\Flatbuffers\BuilderHelpers.h" />
     <ClInclude Include="Includes\CodeGeneration\Flatbuffers\Contants.h" />
+    <ClInclude Include="Includes\Utils\Helpers.h" />
     <ClInclude Include="Includes\VbsEnclaveABI\Enclave\EnclaveHelpers.h" />
     <ClInclude Include="Includes\VbsEnclaveABI\Enclave\MemoryAllocation.h" />
     <ClInclude Include="Includes\VbsEnclaveABI\Enclave\MemoryChecks.h" />

--- a/src/ToolingSharedLibrary/ToolingSharedLibrary.vcxproj.filters
+++ b/src/ToolingSharedLibrary/ToolingSharedLibrary.vcxproj.filters
@@ -75,6 +75,9 @@
     <ClInclude Include="Includes\CodeGeneration\Flatbuffers\BuilderHelpers.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Includes\Utils\Helpers.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">

--- a/tests/UnitTests/TestFiles/ArrayTest.edl
+++ b/tests/UnitTests/TestFiles/ArrayTest.edl
@@ -98,7 +98,7 @@ enclave
             [out] char arg3[3]
         );
 
-        void ArrayQchar_t(
+        void ArrayWchar_t(
             [in] wchar_t arg1[2],
             [in, out] wchar_t arg2[2],
             [out] wchar_t arg3[3]

--- a/tests/UnitTests/TestFiles/ImportTestFiles/CycleImports/A_Cycle.edl
+++ b/tests/UnitTests/TestFiles/ImportTestFiles/CycleImports/A_Cycle.edl
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+enclave
+{
+    import "B_Cycle.edl";
+       
+   enum 
+    {
+         AValue,
+    };
+
+    enum AEnum
+    {
+         value,
+    };
+
+    struct AStruct
+    {
+        int32_t value;
+    };
+
+    trusted
+    {
+        void AFunc();
+    };
+
+    untrusted
+    {
+        void AFunc();
+    };
+};

--- a/tests/UnitTests/TestFiles/ImportTestFiles/CycleImports/B_Cycle.edl
+++ b/tests/UnitTests/TestFiles/ImportTestFiles/CycleImports/B_Cycle.edl
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+enclave
+{
+    import "C_Cycle.edl";
+   
+   enum 
+    {
+         BValue,
+    };
+
+    enum BEnum
+    {
+         value,
+    };
+
+    struct BStruct
+    {
+        int32_t value;
+    };
+
+    trusted
+    {
+        void BFunc();
+    };
+
+    untrusted
+    {
+        void BFunc();
+    };
+};

--- a/tests/UnitTests/TestFiles/ImportTestFiles/CycleImports/C_Cycle.edl
+++ b/tests/UnitTests/TestFiles/ImportTestFiles/CycleImports/C_Cycle.edl
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+enclave
+{
+    import "TestFiles\ImportTestFiles\CycleImports\D_Cycle.edl";
+   
+   enum 
+    {
+         CValue,
+    };
+
+    enum CEnum
+    {
+         value,
+    };
+
+    struct CStruct
+    {
+        int32_t value;
+    };
+
+    trusted
+    {
+        void CFunc();
+    };
+
+    untrusted
+    {
+        void CFunc();
+    };
+};

--- a/tests/UnitTests/TestFiles/ImportTestFiles/CycleImports/D_Cycle.edl
+++ b/tests/UnitTests/TestFiles/ImportTestFiles/CycleImports/D_Cycle.edl
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+enclave
+{   
+   import "A_Cycle.edl";
+
+   enum 
+    {
+         DValue,
+    };
+
+    enum DEnum
+    {
+         value,
+    };
+
+    struct DStruct
+    {
+        int32_t value;
+    };
+
+    trusted
+    {
+        void DFunc();
+    };
+
+    untrusted
+    {
+        void DFunc();
+    };
+};

--- a/tests/UnitTests/TestFiles/ImportTestFiles/DuplicateImports/A_Duplicate.edl
+++ b/tests/UnitTests/TestFiles/ImportTestFiles/DuplicateImports/A_Duplicate.edl
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+enclave
+{
+    import "TestFiles\ImportTestFiles\DuplicateImports\B_Duplicate.edl"; 
+    import "C_Duplicate.edl";
+       
+   enum 
+    {
+         AValue,
+    };
+
+    enum AEnum
+    {
+         value,
+    };
+
+    struct AStruct
+    {
+        int32_t value;
+    };
+
+    trusted
+    {
+        void AFunc();
+    };
+
+    untrusted
+    {
+        void AFunc();
+    };
+};

--- a/tests/UnitTests/TestFiles/ImportTestFiles/DuplicateImports/B_Duplicate.edl
+++ b/tests/UnitTests/TestFiles/ImportTestFiles/DuplicateImports/B_Duplicate.edl
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+enclave
+{
+    import "TestFiles\ImportTestFiles\DuplicateImports\D_Duplicate.edl";
+   
+   enum 
+    {
+         BValue,
+    };
+
+    enum BEnum
+    {
+         value,
+    };
+
+    struct BStruct
+    {
+        int32_t value;
+    };
+
+    trusted
+    {
+        void BFunc();
+    };
+
+    untrusted
+    {
+        void BFunc();
+    };
+};

--- a/tests/UnitTests/TestFiles/ImportTestFiles/DuplicateImports/C_Duplicate.edl
+++ b/tests/UnitTests/TestFiles/ImportTestFiles/DuplicateImports/C_Duplicate.edl
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+enclave
+{
+    import "D_Duplicate.edl";
+   
+   enum 
+    {
+         CValue,
+    };
+
+    enum CEnum
+    {
+         value,
+    };
+
+    struct CStruct
+    {
+        int32_t value;
+    };
+
+    trusted
+    {
+        void CFunc();
+    };
+
+    untrusted
+    {
+        void CFunc();
+    };
+};

--- a/tests/UnitTests/TestFiles/ImportTestFiles/DuplicateImports/D_Duplicate.edl
+++ b/tests/UnitTests/TestFiles/ImportTestFiles/DuplicateImports/D_Duplicate.edl
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+enclave
+{   
+   enum 
+    {
+         DValue,
+    };
+
+    enum DEnum
+    {
+         value,
+    };
+
+    struct DStruct
+    {
+        int32_t value;
+    };
+
+    trusted
+    {
+        void DFunc();
+    };
+
+    untrusted
+    {
+        void DFunc();
+    };
+};

--- a/tests/UnitTests/TestFiles/ImportTestFiles/ImportTest.edl
+++ b/tests/UnitTests/TestFiles/ImportTestFiles/ImportTest.edl
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+enclave
+{
+    import "TestFiles\ArrayTest.edl";
+    import "TestFiles\StructTest.edl";
+    import "TestFiles\BasicTypesTest.edl";
+    import "TestFiles\EnumTest.edl";
+   
+   enum 
+    {
+         Nine,
+    };
+
+    enum NonImportEnum
+    {
+         value,
+    };
+
+    struct NonImportStruct
+    {
+        int32_t value;
+    };
+
+    trusted
+    {
+        void NonImportFunc1();
+    };
+
+    untrusted
+    {
+        void NonImportFunc1();
+    };
+};

--- a/tests/UnitTests/TestFiles/ImportTestFiles/ImproperImportStatementsTest.edl
+++ b/tests/UnitTests/TestFiles/ImportTestFiles/ImproperImportStatementsTest.edl
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+enclave
+{
+    import TestFiles\ArrayTest.edl;
+};

--- a/tests/UnitTests/ToolingExecutableTests/CmdlineArgumentsParserTests.cpp
+++ b/tests/UnitTests/ToolingExecutableTests/CmdlineArgumentsParserTests.cpp
@@ -5,11 +5,10 @@
 #include <CmdlineParsingHelpers.h>
 #include <CmdlineArgumentsParser.h>
 #include "CppUnitTest.h"
+#include "EdlParserTestHelpers.h"
 
 using namespace CmdlineParsingHelpers;
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
-
-const std::string c_edl_path_valid_input = "BasicTypesTest.edl";
 
 namespace VbsEnclaveToolingTests
 {
@@ -32,13 +31,14 @@ namespace VbsEnclaveToolingTests
         TEST_METHOD(TestValidArguments)
         {
             // Simulate command line arguments
+            auto edl_valid_path = c_edl_path_valid_input.generic_string();
             const char* argv[] =
             {
                 m_exe_name.data(),
                 m_lang_arg.data(),
                 m_lang_valid_input.data(),
                 m_edl_path_arg.data(),
-                c_edl_path_valid_input.data(),
+                edl_valid_path.data(),
                 m_out_dir_arg.data(),
                 m_out_dir_valid_input.data(),
                 m_error_handling_arg.data(),
@@ -52,8 +52,8 @@ namespace VbsEnclaveToolingTests
 
             // Test if the parser parsed the arguments correctly
             Assert::IsFalse(parser.ShouldDisplayHelp());
-            Assert::AreEqual(std::string_view(c_edl_path_valid_input), parser.EdlFilePath());
-            Assert::AreEqual(std::string_view(m_out_dir_valid_input), parser.OutDirectory());
+            Assert::AreEqual(c_edl_path_valid_input.generic_string(), parser.EdlFilePath().generic_string());
+            Assert::AreEqual(m_out_dir_valid_input, parser.OutDirectory().generic_string());
             Assert::AreEqual(static_cast<uint32_t>(ErrorHandlingKind::ErrorCode), static_cast<uint32_t>(parser.ErrorHandling()));
             Assert::AreEqual(static_cast<uint32_t>(SupportedLanguageKind::Cpp), static_cast<uint32_t>(parser.SupportedLanguage()));
             Assert::IsTrue(parser.ParseSuccessful());

--- a/tests/UnitTests/ToolingExecutableTests/CmdlineParsingHelpersTests.cpp
+++ b/tests/UnitTests/ToolingExecutableTests/CmdlineParsingHelpersTests.cpp
@@ -62,7 +62,7 @@ TEST_CLASS(CmdlineParsingHelpersTests)
         TEST_METHOD(TestGetEdlPathFromArgs_FileExists)
         {
             char* args[2] = {first_argument.data(), m_test_edl.data()};
-            std::string edl_path;
+            std::filesystem::path edl_path;
 
             // Create a mock file(make sure to clean it up if testing in actual file system)
             std::ofstream file(m_test_edl);
@@ -73,7 +73,7 @@ TEST_CLASS(CmdlineParsingHelpersTests)
 
             // Check that the file exists.
             Assert::AreEqual(static_cast<uint32_t>(ErrorId::Success), static_cast<uint32_t>(result));
-            Assert::AreEqual(m_test_edl, edl_path);
+            Assert::AreEqual(m_test_edl, edl_path.generic_string());
 
             // Cleanup the mock file
             std::filesystem::remove(m_test_edl);
@@ -82,7 +82,7 @@ TEST_CLASS(CmdlineParsingHelpersTests)
         TEST_METHOD(TestGetEdlPathFromArgs_NotAnEdlFile)
         {
             char* args[2] = {first_argument.data(), m_regular_txt_file.data()};
-            std::string edl_path;
+            std::filesystem::path edl_path;
 
             // Create a mock file(make sure to clean it up if testing in actual file system)
             std::ofstream file(m_regular_txt_file);
@@ -93,7 +93,7 @@ TEST_CLASS(CmdlineParsingHelpersTests)
 
             // Make sure edl_path variable hasn't been updated.
             Assert::AreEqual(static_cast<uint32_t>(ErrorId::NotAnEdlFile), static_cast<uint32_t>(result));
-            Assert::AreEqual(std::string(""), edl_path);
+            Assert::AreEqual(std::string(""), edl_path.generic_string());
 
             // Cleanup the mock file
             std::filesystem::remove(m_regular_txt_file);
@@ -102,27 +102,27 @@ TEST_CLASS(CmdlineParsingHelpersTests)
         TEST_METHOD(TestGetEdlPathFromArgs_FileDoesNotExist)
         {
             char* args[2] = {first_argument.data(), m_regular_txt_file.data()};
-            std::string edl_path;
+            std::filesystem::path edl_path;
 
             // Call function
             ErrorId result = GetEdlPathFromArgs(m_starting_index, args, m_args_size, edl_path);
 
             // Check that the file does not exist and that the edl_path_variable hasn't been changed.
             Assert::AreEqual(static_cast<uint32_t>(ErrorId::EdlDoesNotExist), static_cast<uint32_t>(result));
-            Assert::AreEqual(std::string(""), edl_path);
+            Assert::AreEqual(std::string(""), edl_path.generic_string());
         }
 
         TEST_METHOD(TestGetPathToOutputDirectoryFromArgs_Valid)
         {
             char* args[2] = {first_argument.data(), m_cur_directory.data()};
-            std::string directory;
+            std::filesystem::path directory;
 
             // Call function
             ErrorId result = GetPathToOutputDirectoryFromArgs(m_starting_index, args, m_args_size, directory);
 
             // Check that the directory was correctly set
             Assert::AreEqual(static_cast<uint32_t>(ErrorId::Success), static_cast<uint32_t>(result));
-            Assert::AreEqual(std::string("."), directory);
+            Assert::AreEqual(std::string("."), directory.generic_string());
         }
 
         TEST_METHOD(TestGetErrorHandlingFromArg_Valid_ErrorCodeType)
@@ -180,14 +180,14 @@ TEST_CLASS(CmdlineParsingHelpersTests)
         TEST_METHOD(TestGetEdlPathFromArgs_OutOfBounds)
         {
             char* args[2] = {first_argument.data(), m_test_edl.data()};
-            std::string edl_path;
+            std::filesystem::path edl_path;
 
             // Call function
             ErrorId result = GetEdlPathFromArgs(m_invalid_starting_index, args, m_args_size, edl_path);
 
             // Check that no more args result was returned and out param still the same
             Assert::AreEqual(static_cast<uint32_t>(ErrorId::EdlNoMoreArgs), static_cast<uint32_t>(result));
-            Assert::AreEqual(std::string(""), edl_path);
+            Assert::AreEqual(std::string(""), edl_path.generic_string());
         }
 
         TEST_METHOD(TestGetErrorHandlingFromArg_OutOfBounds)
@@ -206,14 +206,14 @@ TEST_CLASS(CmdlineParsingHelpersTests)
         TEST_METHOD(TestGetPathToOutputDirectoryFromArgs_OutOfBounds)
         {
             char* args[2] = {first_argument.data(), m_cur_directory.data()};
-            std::string directory;
+            std::filesystem::path directory;
 
             // Call function
             ErrorId result = GetPathToOutputDirectoryFromArgs(m_invalid_starting_index, args, m_args_size, directory);
 
             // Check that no more args result was returned and out param still the same
             Assert::AreEqual(static_cast<uint32_t>(ErrorId::OutputDirNoMoreArgs), static_cast<uint32_t>(result));
-            Assert::AreEqual(std::string(""), directory);
+            Assert::AreEqual(std::string(""), directory.generic_string());
         }
     };
 }

--- a/tests/UnitTests/ToolingExecutableTests/EdlParserArrayTests.cpp
+++ b/tests/UnitTests/ToolingExecutableTests/EdlParserArrayTests.cpp
@@ -20,10 +20,6 @@ namespace VbsEnclaveToolingTests
 
 TEST_CLASS(EdlParserArrayTests)
 {
-    private:
-
-       std::filesystem::path m_array_edl_file_name = "ArrayTest.edl";
-
     public:
 
     // Trusted functions

--- a/tests/UnitTests/ToolingExecutableTests/EdlParserBasicTypesTests.cpp
+++ b/tests/UnitTests/ToolingExecutableTests/EdlParserBasicTypesTests.cpp
@@ -20,10 +20,6 @@ namespace VbsEnclaveToolingTests
 
 TEST_CLASS(EdlParserBasicTypesTests)
 {
-    private:
-
-    std::filesystem::path m_basic_edl_file_name = "BasicTypesTest.edl";
-
     public:
 
     // Trusted functions

--- a/tests/UnitTests/ToolingExecutableTests/EdlParserEnumTypeTests.cpp
+++ b/tests/UnitTests/ToolingExecutableTests/EdlParserEnumTypeTests.cpp
@@ -20,10 +20,6 @@ namespace VbsEnclaveToolingTests
 
 TEST_CLASS(EdlParserEnumTypeTests)
 {
-    private:
-
-    std::filesystem::path m_enum_edl_file_name = "EnumTest.edl";
-
     public:
 
     // Trusted functions

--- a/tests/UnitTests/ToolingExecutableTests/EdlParserImportTests.cpp
+++ b/tests/UnitTests/ToolingExecutableTests/EdlParserImportTests.cpp
@@ -1,0 +1,133 @@
+// Copyright(c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <pch.h>
+#include "CppUnitTest.h"
+#include <CmdlineParsingHelpers.h>
+#include <Edl\Parser.h>
+#include <Edl\Utils.h>
+#include <unordered_set>
+#include <Exceptions.h>
+#include "EdlParserTestHelpers.h"
+#include <exception>
+
+using namespace ErrorHelpers;
+using namespace ToolingExceptions;
+using namespace EdlProcessor;
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace VbsEnclaveToolingTests
+{
+
+    TEST_CLASS(EdlParserImportTests)
+    {
+        private:
+            std::filesystem::path m_base_imports_path = std::filesystem::current_path() / "TestFiles" / "ImportTestFiles";
+            std::filesystem::path m_edl_file_without_duplicate_imports = m_base_imports_path / "ImportTest.edl";
+            std::filesystem::path m_edl_file_with_duplicate_imports = m_base_imports_path / "DuplicateImports" / "A_Duplicate.edl";
+            std::filesystem::path m_edl_file_with_cycle_imports = m_base_imports_path / "CycleImports" / "A_Cycle.edl";
+
+            void ParseEdlFileWithImports(
+                std::filesystem::path edl_file,
+                std::vector<std::filesystem::path> import_directories,
+                size_t trusted_function_list_size,
+                size_t untrusted_function_list_size,
+                std::unordered_set<std::string>& m_dev_type_names)
+            {
+                std::filesystem::path running_test_dir = std::filesystem::current_path();
+                auto edl_parser = EdlParser(edl_file, import_directories);
+                Edl edl = edl_parser.Parse();
+
+                // Verify edl contains all functions from all the imported functions
+                Assert::AreEqual(trusted_function_list_size, edl.m_trusted_functions.size());
+                Assert::AreEqual(untrusted_function_list_size, edl.m_untrusted_functions.size());
+
+                auto check_functions_expected = [&] (OrderedMap<std::string, Function>& functions)
+                {
+                    for (auto& [name, function] : functions)
+                    {
+                        auto& expected_signature = c_test_func_signatures.at(function.m_name);
+                        Assert::AreEqual(expected_signature, function.GetDeclarationSignature());
+                    }
+                };
+
+                check_functions_expected(edl.m_trusted_functions);
+                check_functions_expected(edl.m_untrusted_functions);
+
+                // Verify developer types were added to edl object
+                Assert::AreEqual(m_dev_type_names.size(), edl.m_developer_types.size());
+                for (auto& dev_type_name : edl.m_developer_types.keys())
+                {
+                    auto& dev_type = edl.m_developer_types.at(dev_type_name);
+                    Assert::IsTrue(m_dev_type_names.contains(dev_type.m_name));
+                }
+            }
+
+        public:
+
+            // Trusted functions
+        TEST_METHOD(Parse_edl_file_without_duplicate_or_cycle_imports)
+        {
+            std::unordered_set<std::string> m_dev_type_names =
+            {
+                "__anonymous_enum",
+                "MyStruct1",
+                "MyStruct0",
+                "NonImportStruct",
+                "NonImportEnum",
+                "Color",
+            };
+
+            auto num_of_functions_to_parse = 31; // 31 trusted and 31 untrusted
+            ParseEdlFileWithImports(
+                m_edl_file_without_duplicate_imports,
+                {std::filesystem::current_path()},
+                num_of_functions_to_parse,
+                num_of_functions_to_parse,
+                m_dev_type_names);
+        }
+
+        TEST_METHOD(Parse_Edl_file_with_duplicate_imports)
+        {
+            std::unordered_set<std::string> m_dev_type_names =
+            {
+                "__anonymous_enum",
+                "AEnum",
+                "AStruct",
+                "BEnum",
+                "BStruct",
+                "CEnum",
+                "CStruct",
+                "DEnum",
+                "DStruct",
+            };
+
+            auto duplicate_dir = m_base_imports_path / "DuplicateImports";
+                auto directories = {std::filesystem::current_path(), duplicate_dir};
+                auto num_of_functions_to_parse = 4;// 4 trusted and 4 untrusted
+                ParseEdlFileWithImports(
+                    m_edl_file_with_duplicate_imports,
+                    directories,
+                    num_of_functions_to_parse,
+                    num_of_functions_to_parse,
+                    m_dev_type_names);
+            }
+
+            TEST_METHOD(Parse_Edl_file_with_cycle_in_imports)
+            {
+                auto cycle_dir = m_base_imports_path / "CycleImports";
+                auto directories = {std::filesystem::current_path(), cycle_dir};
+                auto edl_parser = EdlParser(m_edl_file_with_cycle_imports, directories);
+
+                try
+                {   
+                    Edl edl = edl_parser.Parse();
+                }
+                catch (EdlAnalysisException& ex)
+                {                    
+                    Assert::AreEqual(static_cast<std::uint32_t>(ErrorId::ImportCycleFound), static_cast<std::uint32_t>(ex.GetErrorId()));
+                }
+            }
+
+    };
+}

--- a/tests/UnitTests/ToolingExecutableTests/EdlParserStructTypesTests.cpp
+++ b/tests/UnitTests/ToolingExecutableTests/EdlParserStructTypesTests.cpp
@@ -20,9 +20,6 @@ namespace VbsEnclaveToolingTests
 
 TEST_CLASS(EdlParserStructTypeTests)
 {
-    private:
-
-    std::filesystem::path m_struct_edl_file_name = "StructTest.edl";
     public:
 
     // Trusted functions

--- a/tests/UnitTests/ToolingExecutableTests/EdlParserTestHelpers.h
+++ b/tests/UnitTests/ToolingExecutableTests/EdlParserTestHelpers.h
@@ -17,8 +17,13 @@ using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
 namespace VbsEnclaveToolingTests
 {
+    static std::filesystem::path m_array_edl_file_name = "TestFiles\\ArrayTest.edl";
+    static std::filesystem::path m_basic_edl_file_name = "TestFiles\\BasicTypesTest.edl";
+    static std::filesystem::path m_enum_edl_file_name = "TestFiles\\EnumTest.edl";
+    static std::filesystem::path m_struct_edl_file_name = "TestFiles\\StructTest.edl";
+    static std::filesystem::path c_edl_path_valid_input = "TestFiles\\BasicTypesTest.edl";
 
-    static const std::unordered_map<std::string, std::string> test_func_signatures =
+    static const std::unordered_map<std::string, std::string> c_test_func_signatures =
     {
         // ArrayTest.edl expected function signatures where key is function name and value is its signature
 
@@ -64,6 +69,21 @@ namespace VbsEnclaveToolingTests
 
         {"TrustedGetStruct1", "TrustedGetStruct1(MyStruct1,MyStruct1[5],MyStruct1[5],MyStruct1[1],MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,size_t,size_t)"},
         {"UntrustedGetStruct1", "UntrustedGetStruct1(MyStruct1,MyStruct1[5],MyStruct1[5],MyStruct1[1],MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,MyStruct1*,size_t,size_t)"},
+
+        // ImportTest.edl function signatures where key is the function name and value is its signature
+        { "NonImportFunc1", "NonImportFunc1()"},
+
+        // A.edl function signatures where key is the function name and value is its signature
+        { "AFunc", "AFunc()" },
+
+        // B.edl function signatures where key is the function name and value is its signature
+        { "BFunc", "BFunc()" },
+
+        // C.edl function signatures where key is the function name and value is its signature
+        { "CFunc", "CFunc()" },
+
+        // D.edl function signatures where key is the function name and value is its signature
+        { "DFunc", "DFunc()" },
     };
 
     static inline std::wstring ConvertExceptionMessageToWstring(const std::exception& exception)
@@ -78,24 +98,24 @@ namespace VbsEnclaveToolingTests
         const std::string& function_name,
         const FunctionKind& function_kind)
     {
-        auto edl_parser = EdlParser(test_file_name);
+        auto edl_parser = EdlParser(test_file_name, {"."});
         Edl edl = edl_parser.Parse();
 
         // Verify function name
         Assert::AreEqual(edl.m_name, test_file_name.stem().generic_string());
 
-        auto expected_signature = test_func_signatures.at(function_name);
+        auto expected_signature = c_test_func_signatures.at(function_name);
         Function function;
 
         if (function_kind == FunctionKind::Trusted)
         {
-            Assert::IsTrue(edl.m_trusted_functions_map.contains(expected_signature));
-            function = edl.m_trusted_functions_map.at(expected_signature);
+            Assert::IsTrue(edl.m_trusted_functions.contains(expected_signature));
+            function = edl.m_trusted_functions.at(expected_signature);
         }
         else
         {
-            Assert::IsTrue(edl.m_untrusted_functions_map.contains(expected_signature));
-            function = edl.m_untrusted_functions_map.at(expected_signature);
+            Assert::IsTrue(edl.m_untrusted_functions.contains(expected_signature));
+            function = edl.m_untrusted_functions.at(expected_signature);
         }
 
          // Confirm function signature is expected signature.

--- a/tests/UnitTests/ToolingExecutableTests/LexicalAnalyzerTests.cpp
+++ b/tests/UnitTests/ToolingExecutableTests/LexicalAnalyzerTests.cpp
@@ -21,10 +21,7 @@ namespace VbsEnclaveToolingTests
 TEST_CLASS(LexicalAnalyzerTests)
 {
     private:
-        std::filesystem::path m_array_edl_file_name = "ArrayTest.edl";
-        std::filesystem::path m_basic_edl_file_name = "BasicTypesTest.edl";
-        std::filesystem::path m_enum_edl_file_name = "EnumTest.edl";
-        std::filesystem::path m_struct_edl_file_name = "StructTest.edl";
+
         std::unordered_set<char> m_valid_char_tokens =
         {
             RIGHT_CURLY_BRACKET,

--- a/tests/UnitTests/UnitTests.vcxproj
+++ b/tests/UnitTests/UnitTests.vcxproj
@@ -198,6 +198,7 @@
     <ClCompile Include="ToolingExecutableTests\EdlParserBasicTypesTests.cpp" />
     <ClCompile Include="ToolingExecutableTests\EdlParserArrayTests.cpp" />
     <ClCompile Include="ToolingExecutableTests\EdlParserEnumTypeTests.cpp" />
+    <ClCompile Include="ToolingExecutableTests\EdlParserImportTests.cpp" />
     <ClCompile Include="ToolingExecutableTests\EdlParserStructTypesTests.cpp" />
     <ClCompile Include="ToolingExecutableTests\ErrorHelpersTests.cpp" />
     <ClCompile Include="pch.cpp">
@@ -222,35 +223,48 @@
   <ItemGroup>
     <None Include="packages.config" />
     <None Include="README.md" />
-    <CopyFileToFolders Include="TestFiles\ArrayTest.edl">
-      <FileType>Document</FileType>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</DeploymentContent>
-    </CopyFileToFolders>
-    <CopyFileToFolders Include="TestFiles\BasicTypesTest.edl">
-      <FileType>Document</FileType>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</DeploymentContent>
-    </CopyFileToFolders>
-    <CopyFileToFolders Include="TestFiles\EnumTest.edl">
-      <FileType>Document</FileType>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</DeploymentContent>
-    </CopyFileToFolders>
-    <CopyFileToFolders Include="TestFiles\StructTest.edl">
-      <FileType>Document</FileType>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</DeploymentContent>
-    </CopyFileToFolders>
-    <None Include="TestFiles\TrustedFunctionsCodeGen.edl" />
+    <None Include="TestFiles\ArrayTest.edl">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestFiles\BasicTypesTest.edl">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestFiles\EnumTest.edl">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestFiles\ImportTestFiles\CycleImports\A_Cycle.edl">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestFiles\ImportTestFiles\CycleImports\B_Cycle.edl">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestFiles\ImportTestFiles\CycleImports\C_Cycle.edl">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestFiles\ImportTestFiles\CycleImports\D_Cycle.edl">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestFiles\ImportTestFiles\DuplicateImports\A_Duplicate.edl">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestFiles\ImportTestFiles\DuplicateImports\B_Duplicate.edl">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestFiles\ImportTestFiles\DuplicateImports\C_Duplicate.edl">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestFiles\ImportTestFiles\DuplicateImports\D_Duplicate.edl">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestFiles\ImportTestFiles\ImportTest.edl">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestFiles\ImportTestFiles\ImproperImportStatementsTest.edl">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestFiles\StructTest.edl">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/tests/UnitTests/UnitTests.vcxproj.filters
+++ b/tests/UnitTests/UnitTests.vcxproj.filters
@@ -42,6 +42,9 @@
     <ClCompile Include="ToolingExecutableTests\EdlParserStructTypesTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ToolingExecutableTests\EdlParserImportTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h">
@@ -53,13 +56,23 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="README.md" />
-    <None Include="TestFiles\TrustedFunctionsCodeGen.edl" />
     <None Include="packages.config" />
+    <None Include="TestFiles\ImportTestFiles\ImproperImportStatementsTest.edl" />
+    <None Include="TestFiles\ArrayTest.edl" />
+    <None Include="TestFiles\BasicTypesTest.edl" />
+    <None Include="TestFiles\EnumTest.edl" />
+    <None Include="TestFiles\ImportTestFiles\ImportTest.edl" />
+    <None Include="TestFiles\StructTest.edl" />
+    <None Include="TestFiles\ImportTestFiles\DuplicateImports\A_Duplicate.edl" />
+    <None Include="TestFiles\ImportTestFiles\DuplicateImports\B_Duplicate.edl" />
+    <None Include="TestFiles\ImportTestFiles\DuplicateImports\C_Duplicate.edl" />
+    <None Include="TestFiles\ImportTestFiles\DuplicateImports\D_Duplicate.edl" />
+    <None Include="TestFiles\ImportTestFiles\CycleImports\A_Cycle.edl" />
+    <None Include="TestFiles\ImportTestFiles\CycleImports\B_Cycle.edl" />
+    <None Include="TestFiles\ImportTestFiles\CycleImports\C_Cycle.edl" />
+    <None Include="TestFiles\ImportTestFiles\CycleImports\D_Cycle.edl" />
   </ItemGroup>
   <ItemGroup>
-    <CopyFileToFolders Include="TestFiles\ArrayTest.edl" />
-    <CopyFileToFolders Include="TestFiles\BasicTypesTest.edl" />
-    <CopyFileToFolders Include="TestFiles\EnumTest.edl" />
-    <CopyFileToFolders Include="TestFiles\StructTest.edl" />
+    <Natvis Include="$(MSBuildThisFileDirectory)..\..\natvis\wil.natvis" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Why is this change needed?

To provide EDL import support to improve reusability of edl files.

## What changed?

**EdlCodeGen.exe Command line**:
  * Switched file path handling from `std::string` to `std::filesystem::path`.
  * Added `--ImportDirectories` Command line argument. We will use these directories when attempting to find the imported edl files.
 
**EDL Parsing**:

  * Added `import` statement parsing in `.edl` files. Now developers can import edl files using `import "myEdlFile.edl";`. `Note` the value within the quotes can be an absolute path or a relative path in one of the directories listed in the `--ImportDirectories` argument.
  * Provided the ability for the parser to understand duplicate/redundant imports and imports that cause a cycle.
**Data Structures**:

  * Introduced a simple `OrderedMap` for developer types and functions (preserves insertion order while still giving us fast lookups). This replaced the unordered_map + vector combos I was passing throughout parsing and codegen functions.
**Tests & Misc**:

## How as it tested?
* I added unit tests for imports, cycle, and duplicate scenarios which can be invoked via the Test Explorer in VS.