### PR TITLE
Add <VbsEnclaveImportDirectories /> property to nuget props and targets files

### DIFF
--- a/src/ToolingNuget/Nuget/Microsoft.Windows.VbsEnclave.CodeGenerator.props
+++ b/src/ToolingNuget/Nuget/Microsoft.Windows.VbsEnclave.CodeGenerator.props
@@ -12,6 +12,7 @@
         <VbsEnclaveVirtualTrustLayer Condition="'$(VbsEnclaveVirtualTrustLayer)' == ''">HostApp</VbsEnclaveVirtualTrustLayer>
         <VbsEnclaveVtl0ClassName></VbsEnclaveVtl0ClassName>
         <VbsEnclaveNamespace></VbsEnclaveNamespace>
+        <VbsEnclaveImportDirectories></VbsEnclaveImportDirectories>
         <!-- End -->
     </PropertyGroup>
 </Project>

--- a/src/ToolingNuget/Nuget/Microsoft.Windows.VbsEnclave.CodeGenerator.targets
+++ b/src/ToolingNuget/Nuget/Microsoft.Windows.VbsEnclave.CodeGenerator.targets
@@ -32,7 +32,7 @@
         <!-- Generate the codegen files using the vbsenclavetooling-->
         <PropertyGroup>
             <VbsEnclaveToolingExecutionCommand>
-                "$(VbsEnclaveExeFilePath)" --Language "$(VbsEnclaveCodeGenLanguage)" --EdlPath "$(VbsEnclaveEdlPath)" --ErrorHandling "$(VbsEnclaveErrorHandling)" --OutputDirectory "$(VbsEnclaveGeneratedFilesDir)" --VirtualTrustLayer "$(VbsEnclaveVirtualTrustLayer)" --Vtl0ClassName "$(VbsEnclaveVtl0ClassName)" --Namespace "$(VbsEnclaveNamespace)" --FlatbuffersCompilerPath "$(FlatbuffersCompiler)"
+                "$(VbsEnclaveExeFilePath)" --Language "$(VbsEnclaveCodeGenLanguage)" --EdlPath "$(VbsEnclaveEdlPath)" --ErrorHandling "$(VbsEnclaveErrorHandling)" --OutputDirectory "$(VbsEnclaveGeneratedFilesDir)" --VirtualTrustLayer "$(VbsEnclaveVirtualTrustLayer)" --Vtl0ClassName "$(VbsEnclaveVtl0ClassName)" --Namespace "$(VbsEnclaveNamespace)" --FlatbuffersCompilerPath "$(FlatbuffersCompiler)" --ImportDirectories "$(VbsEnclaveImportDirectories)"
             </VbsEnclaveToolingExecutionCommand>
         </PropertyGroup>
 


### PR DESCRIPTION
### Why is this change needed?
Missed updating `Microsoft.Windows.VbsEnclave.CodeGenerator.props` and `Microsoft.Windows.VbsEnclave.CodeGenerator.targets`   with the `<VbsEnclaveImportDirectories />`  property, so nuget consumers can pass their import directories to `edlcodegen.exe` 
