### PR TITLE
Fix parser incorrectly reporting imported types as undefined

### DIFF
--- a/src/ToolingSharedLibrary/Includes/Edl/Parser.h
+++ b/src/ToolingSharedLibrary/Includes/Edl/Parser.h
@@ -96,8 +96,7 @@ namespace EdlProcessor
 
         Token PeekAtCurrentToken();
         Token PeekAtNextToken();
-        Edl ParseBody(std::unordered_map<std::filesystem::path, ParsedState>& parsed_files);
-        Edl GenerateEdlObject(std::unordered_map<std::filesystem::path, ParsedState>& parsed_files);
+        void ParseBody(std::unordered_map<std::filesystem::path, ParsedState>& parsed_files);
         void ParseImport(std::unordered_map<std::filesystem::path, ParsedState>& parsed_files);
         Function ParseFunctionDeclaration();
         EdlTypeInfo ParseDeclarationTypeInfo();
@@ -119,10 +118,7 @@ namespace EdlProcessor
         std::uint32_t m_cur_line {};
         std::uint32_t m_cur_column {};
         std::unordered_set<std::string> m_unresolved_types{};
-        OrderedMap<std::string, DeveloperType> m_developer_types {};
-        OrderedMap<std::string, Function> m_trusted_functions;
-        OrderedMap<std::string, Function> m_untrusted_functions;
+        Edl m_edl {};
         std::vector<std::filesystem::path> m_import_directories {};
-        std::vector<std::filesystem::path> m_imported_edl_files {};
     };
 }

--- a/src/ToolingSharedLibrary/Includes/Edl/Structures.h
+++ b/src/ToolingSharedLibrary/Includes/Edl/Structures.h
@@ -430,7 +430,7 @@ namespace EdlProcessor
         }
 
         std::string m_name{};
-        std::optional<Token> m_value{};
+        std::optional<std::string> m_value{};
 
         // When the value isn't defined with an '=' symbol, the value of the enum
         // will be the position it appears in the edl file. e.g first will be 0,

--- a/src/ToolingSharedLibrary/Includes/ErrorHelpers.h
+++ b/src/ToolingSharedLibrary/Includes/ErrorHelpers.h
@@ -85,10 +85,6 @@ namespace ErrorHelpers
         ImportDirectoriesNoMoreArgs,
         ImportDirectoryDoesNotExist,
         ImportedEdlFileDoesNotExist,
-        DuplicateDevTypeInImportFile,
-        DuplicateTrustedFunctionInImportFile,
-        DuplicateUntrustedFunctionInImportFile,
-        DuplicateAnonEnumValueInImportFile,
         ImportCycleFound,
     };
 
@@ -122,10 +118,6 @@ namespace ErrorHelpers
         { ErrorId::ImportDirectoriesNoMoreArgs,"Unable to find import directiories. No more commandline arguments available to find edl import directories." },
         { ErrorId::ImportDirectoryDoesNotExist,"The import directory '{}' does not exist or is not a directory." },
         { ErrorId::ImportedEdlFileDoesNotExist, "import file '{}' was not found for '{}'. Check that the .edl file exists in your import directories." },
-        { ErrorId::DuplicateDevTypeInImportFile, "Found duplicate type '{}' in import file '{}' when parsing '{}'. Types must only be defined once per .edl file." },
-        { ErrorId::DuplicateTrustedFunctionInImportFile, "Found duplicate trusted function '{}' in import file '{}' when parsing '{}'. Functions must only be defined once per scope (trusted/untrusted), per .edl file." },
-        { ErrorId::DuplicateUntrustedFunctionInImportFile, "Found duplicate untrusted function '{}' in import file '{}' when parsing '{}'. Functions must only be defined once per scope (trusted/untrusted), per .edl file." },
-        { ErrorId::DuplicateAnonEnumValueInImportFile, "Found duplicate anonymous enum value '{}' in import file '{}' when parsing '{}'. A named value inside the anonymous enum can only be defined once for all .edl files." },
         { ErrorId::ImportCycleFound, "Import cycle found when attempting to import '{}' into '{}'." },
 
         // Edl file lexical analysis errors

--- a/src/ToolingSharedLibrary/ToolingExecutable/CodeGeneration/CppCodeBuilder.cpp
+++ b/src/ToolingSharedLibrary/ToolingExecutable/CodeGeneration/CppCodeBuilder.cpp
@@ -167,8 +167,7 @@ namespace CodeGeneration
             if (enum_value.m_value)
             {
                 // Value was the enum name for a value within the anonymous enum.
-                Token value_token = enum_value.m_value.value();
-                enum_body << std::format("{}{} = {},\n", body_tab_count, enum_value.m_name, value_token.ToString());
+                enum_body << std::format("{}{} = {},\n", body_tab_count, enum_value.m_name, enum_value.m_value.value());
             }
             else if (enum_value.m_is_hex)
             {

--- a/src/ToolingSharedLibrary/ToolingExecutable/CodeGeneration/Flatbuffers/BuilderHelpers.cpp
+++ b/src/ToolingSharedLibrary/ToolingExecutable/CodeGeneration/Flatbuffers/BuilderHelpers.cpp
@@ -64,8 +64,7 @@ namespace CodeGeneration::Flatbuffers
             if (enum_value.m_value)
             {
                 // Raw value will only ever be an numeric value.
-                Token value_token = enum_value.m_value.value();
-                enum_body << std::format("    {} = {},\n", enum_value.m_name, value_token.ToString());
+                enum_body << std::format("    {} = {},\n", enum_value.m_name, enum_value.m_value.value());
             }
             else
             {

--- a/tests/EnclaveTests/CodeGenEndToEndTests/CodeGenEndToEndTests.sln
+++ b/tests/EnclaveTests/CodeGenEndToEndTests/CodeGenEndToEndTests.sln
@@ -14,6 +14,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		CodeGenTestFunctions.edl = CodeGenTestFunctions.edl
 		nuget.config = nuget.config
+		CodeGenTestTypes.edl = CodeGenTestTypes.edl
 		README.md = README.md
 		run-enclave-tests.ps1 = run-enclave-tests.ps1
 		TestEnclaveAndHostAppShared.targets = TestEnclaveAndHostAppShared.targets

--- a/tests/EnclaveTests/CodeGenEndToEndTests/CodeGenTestFunctions.edl
+++ b/tests/EnclaveTests/CodeGenEndToEndTests/CodeGenTestFunctions.edl
@@ -3,54 +3,13 @@
 // File used for testing purposes
 
 enclave
-{
+{   
+    import "CodeGenTestTypes.edl";
+
     // Anonymous enum
     enum
     {
-        value1 = 10,
         value2 = 50,
-    };
-
-    // Hexidecimal enum example
-     enum HexEnum 
-     {
-        Hex_val1 = 0x01,
-        Hex_val2,
-        Hex_val3,
-        Hex_val4 = 0xFF
-    };
-
-    // Decimal enum example
-    enum DecimalEnum 
-     {
-        Deci_val1,
-        Deci_val2,
-        Deci_val3,
-    };
-
-    struct NestedStructNoPointers
-    {
-        int64_t value_in_nested_struct;
-    };
-
-    struct StructWithNoPointers
-    {
-        bool bool_val;
-        int8_t int8_val;
-        int16_t int16_val;
-        int32_t int32_val;
-        int64_t int64_val;
-        uint8_t uint8_val;
-        uint16_t uint16_val;
-        uint32_t uint32_val;
-        uint64_t uint64_val;
-
-        HexEnum hex_val;
-        DecimalEnum deci_val;
-
-        NestedStructNoPointers nested_struct_val;
-
-        HRESULT result;
     };
 
     struct NestedStructWithArray

--- a/tests/EnclaveTests/CodeGenEndToEndTests/CodeGenTestTypes.edl
+++ b/tests/EnclaveTests/CodeGenEndToEndTests/CodeGenTestTypes.edl
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// File used for testing purposes
+
+enclave
+{
+    // Anonymous enum
+    enum
+    {
+        value1 = 10,
+    };
+
+    // Hexidecimal enum example
+     enum HexEnum 
+     {
+        Hex_val1 = 0x01,
+        Hex_val2,
+        Hex_val3,
+        Hex_val4 = 0xFF
+    };
+
+    // Decimal enum example
+    enum DecimalEnum 
+     {
+        Deci_val1,
+        Deci_val2,
+        Deci_val3,
+    };
+
+    struct NestedStructNoPointers
+    {
+        int64_t value_in_nested_struct;
+    };
+
+    struct StructWithNoPointers
+    {
+        bool bool_val;
+        int8_t int8_val;
+        int16_t int16_val;
+        int32_t int32_val;
+        int64_t int64_val;
+        uint8_t uint8_val;
+        uint16_t uint16_val;
+        uint32_t uint32_val;
+        uint64_t uint64_val;
+
+        HexEnum hex_val;
+        DecimalEnum deci_val;
+
+        NestedStructNoPointers nested_struct_val;
+
+        HRESULT result;
+    };
+};

--- a/tests/EnclaveTests/CodeGenEndToEndTests/TestEnclaveAndHostAppShared.targets
+++ b/tests/EnclaveTests/CodeGenEndToEndTests/TestEnclaveAndHostAppShared.targets
@@ -4,5 +4,6 @@
         <VbsEnclaveEdlPath>$(ProjectDir)..\CodeGenTestFunctions.edl</VbsEnclaveEdlPath>
         <VbsEnclaveVtl0ClassName>TestEnclave</VbsEnclaveVtl0ClassName>
         <VbsEnclaveNamespace>VbsEnclave</VbsEnclaveNamespace>
+        <VbsEnclaveImportDirectories>$(SolutionDir)\</VbsEnclaveImportDirectories>
     </PropertyGroup>
 </Project>

--- a/tests/UnitTests/TestFiles/EnumTest.edl
+++ b/tests/UnitTests/TestFiles/EnumTest.edl
@@ -20,8 +20,9 @@ enclave
     // Anonymous enum
     enum 
     {
-        Nine = 100,
-        Ten = 200
+        Nine = 9,
+        Ten = 10,
+        Fifteen = 15
     };
 
     trusted 

--- a/tests/UnitTests/TestFiles/ImportTestFiles/ImportTest.edl
+++ b/tests/UnitTests/TestFiles/ImportTestFiles/ImportTest.edl
@@ -21,15 +21,20 @@ enclave
     struct NonImportStruct
     {
         int32_t value;
+        MyStruct2 *mystruct2_ptr;
+        Color color;
+        int32_t arr[Eleven];
     };
 
     trusted
     {
         void NonImportFunc1();
+        void NonImportFuncWithArrayArgs1(int32_t value[Nine], MyStruct2 my_struct);
     };
 
     untrusted
     {
         void NonImportFunc1();
+        void NonImportFuncWithArrayArgs2(int32_t value[Fifteen]);
     };
 };

--- a/tests/UnitTests/ToolingExecutableTests/EdlParserImportTests.cpp
+++ b/tests/UnitTests/ToolingExecutableTests/EdlParserImportTests.cpp
@@ -79,16 +79,16 @@ namespace VbsEnclaveToolingTests
                 "NonImportEnum",
                 "Color",
             };
-
-            // 34 trusted and 34 untrusted. Should match number of values in `c_test_func_signatures`
+            
+            // 35 trusted and 35 untrusted. Should match number of values in `c_test_func_signatures`
             // which is located in EdlParserTestHelpers.h
-            auto num_of_functions_to_parse = 34;
+            auto num_of_functions_to_parse = 35;
             ParseEdlFileWithImports(
                 m_edl_file_without_duplicate_imports,
                 {std::filesystem::current_path()},
                 num_of_functions_to_parse,
                 num_of_functions_to_parse,
-                dev_type_names);
+                dev_type_names);            
         }
 
         TEST_METHOD(Parse_Edl_file_with_duplicate_imports)
@@ -106,7 +106,7 @@ namespace VbsEnclaveToolingTests
                 "DStruct",
             };
 
-            auto duplicate_dir = m_base_imports_path / "DuplicateImports";
+                auto duplicate_dir = m_base_imports_path / "DuplicateImports";
                 auto directories = {std::filesystem::current_path(), duplicate_dir};
                 auto num_of_functions_to_parse = 4;// 4 trusted and 4 untrusted
                 ParseEdlFileWithImports(
@@ -148,7 +148,7 @@ namespace VbsEnclaveToolingTests
                     }
                     catch (EdlAnalysisException& ex)
                     {
-                        Assert::AreEqual(static_cast<std::uint32_t>(ErrorId::DuplicateAnonEnumValueInImportFile), static_cast<std::uint32_t>(ex.GetErrorId()));
+                        Assert::AreEqual(static_cast<std::uint32_t>(ErrorId::EdlEnumNameDuplicated), static_cast<std::uint32_t>(ex.GetErrorId()));
                         throw;
                     }
                 });

--- a/tests/UnitTests/ToolingExecutableTests/EdlParserTestHelpers.h
+++ b/tests/UnitTests/ToolingExecutableTests/EdlParserTestHelpers.h
@@ -75,6 +75,8 @@ namespace VbsEnclaveToolingTests
 
         // ImportTest.edl function signatures where key is the function name and value is its signature
         { "NonImportFunc1", "NonImportFunc1()"},
+        { "NonImportFuncWithArrayArgs1", "NonImportFuncWithArrayArgs1(int32_t[Nine],MyStruct2)"},
+        { "NonImportFuncWithArrayArgs2", "NonImportFuncWithArrayArgs2(int32_t[Fifteen])"},
 
         // A.edl function signatures where key is the function name and value is its signature
         { "AFunc", "AFunc()" },


### PR DESCRIPTION
### Why is this change needed?
1. I realized after the fact that we could simplify merging imported `.edl` files by updating a single `edl` object during parsing, rather than collecting data in separate structures and generating the final `edl` at the end. With this change, imports are merged immediately into the parser's `edl` object as they are parsed, eliminating the need for a separate conflict resolution step.

2. Noticed that while the parser correctly parses imported `.edl` files, it fails when returning to parse the original `.edl` file in the following scenario:

`A.edl` contains:
```c++
enum 
{
  Fifteen = 15,
};

`A.edl` contains
```C++
enum 
{
  Fifteen = 15,
};
```
and `B.edl` contains
```C++
import "A.edl";

// Struct example
struct Some_Struct
{
   uint32_t arr[Fifteen];
};

// Function example
trusted
{
    void SomeFunction(uint32_t arr[Fifteen]);
};
```

Parsing fails with an error stating that `Fifteen` is undefined. This happens because the parser only considered `developer_types` defined in `B.edl` when validating types and function parameters in `B.edl`. The parser should maintain an object that contains all the imported types and local types to prevent this.

### What changed?

**EdlParser**:
- Consolidated internal parser state (`m_developer_types`, `m_trusted_functions`, `m_untrusted_functions`) into a single `m_edl` object to avoid duplicated logic and ensure consistent access to both local and imported definitions during parsing.
- Parser now contains an edl object itself that it updates during the parsing, so there is no need for the `GenerateEdlObject` function.
- Enum value representation simplified from `Token` to `std::string`.

### How was this tested?
  - `ImportTest.edl` now has functions that use array parameters referencing anonymous enum values and structs from imported files.
  - Moved some types that were in `CodeGenTestFunctions.edl` to a new file `CodeGenTestTypes.edl` in the CodeGen test solution so we have the end to end tests using imports as well. Confirmed all tests still passing and solution can be built
  - Updated `Parse_Edl_file_with_duplicate_anonymous_enum_values_in_imports` test to expect `ErrorId::EdlEnumNameDuplicated` error.
