### PR TITLE
move pool parameter in Azure pipeline template out of stages scope to file scope

### DIFF
--- a/AzurePipelineTemplates/OneBranch.Official.yml
+++ b/AzurePipelineTemplates/OneBranch.Official.yml
@@ -21,6 +21,9 @@ variables:
 
 trigger: none
 
+pool:
+  type: windows
+
 resources:
   repositories: 
     - repository: templates
@@ -64,8 +67,6 @@ extends:
       - stage: Build_codegen
         displayName: 'Build CodeGenerator'
         condition: eq('${{ parameters.BuildTarget }}', 'CodeGen')
-        pool:
-         type: windows
         jobs:
         - template: AzurePipelineTemplates/jobs/CodeGenBuildJob.yml@self
           parameters:
@@ -75,8 +76,6 @@ extends:
       - stage: Build_veil_sdk
         displayName: 'Build SDK'
         condition: eq('${{ parameters.BuildTarget }}', 'SDK')
-        pool:
-          type: windows
         jobs:
         - template: AzurePipelineTemplates/jobs/SdkBuildJob.yml@self
           parameters:


### PR DESCRIPTION
Looks like there was a recent change to the one branch templates, that prevent the pool tag from being used under stages. To fix this I moved them above to the file scope. Confirmed [Codegen](https://microsoft.visualstudio.com/Dart/_build/results?buildId=127438492&view=results) and [SDK](https://microsoft.visualstudio.com/Dart/_build/results?buildId=127438511&view=results) builds completed successfully in private pipeline builds.