### PR TITLE
Move conditional in release pipeline to variable scope

### DIFF
--- a/AzurePipelineTemplates/jobs/PublishNugetPackages.yml
+++ b/AzurePipelineTemplates/jobs/PublishNugetPackages.yml
@@ -18,6 +18,12 @@ resources:
     source: 'Vbs Enclave Tooling OneBranch (Official Build)'
     trigger: none
 
+variables:
+  ${{ if eq(parameters.ReleaseTarget, 'CodeGen') }}:
+    ArtifactName: 'signed_codegen_nuget_package'
+  ${{ else }}:
+    ArtifactName: 'signed_sdk_nuget_package'
+
 extends:
   template: v2/OneBranch.Official.CrossPlat.yml@templates
   parameters:
@@ -39,14 +45,8 @@ extends:
         templateContext:
           inputs:
           - input: pipelineArtifact
-            condition: eq('${{ parameters.ReleaseTarget }}', 'CodeGen')
             pipeline: VbsEnclaveTooling
-            artifactName: signed_codegen_nuget_package
-
-          - input: pipelineArtifact
-            condition: eq('${{ parameters.ReleaseTarget }}', 'SDK')
-            pipeline: VbsEnclaveTooling
-            artifactName: signed_sdk_nuget_package
+            artifactName: $(ArtifactName)
 
         steps:
         - task: NuGetCommand@2


### PR DESCRIPTION
Turns out even though it's valid to place conditionals under the input scope, azure pipelines still attempt to input the resource when the condition is `false`. In the case of passing `CodeGen` as a parameter, the pipeline retrieves the artifacts, then still attempts to retrieve the `SDK` artifacts even though they don't exist.

To fix this, I use a conditional to set the name of the artifact based on the passed in parameter, instead of placing the conditionals directly inside the `- input` scope.