### PR TITLE
Add /FS compiler flag to the veil_enclave_lib project

### DIFF
--- a/src/VbsEnclaveSDK/src/veil_enclave_lib/veil_enclave_lib.vcxproj
+++ b/src/VbsEnclaveSDK/src/veil_enclave_lib/veil_enclave_lib.vcxproj
@@ -97,6 +97,12 @@
       <AdditionalIncludeDirectories>$(WindowsSdk_EnclaveIncludes_Path)\um;$(WindowsSdk_EnclaveIncludes_Path)\shared;$(WindowsSdk_EnclaveIncludes_Path)\ucrt;$(SolutionDir)..\..\Common\veil_enclave_wil_inc;$(MSBUILDThisFileDirectory)..\veil_enclave_inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <GuardEHContMetadata>true</GuardEHContMetadata>
+        <!-- 
+          Add /FS to enable file-based locking on .pdb files. Without this, parallel cl.exe processes
+          (as used by vcpkg builds) can collide when writing debug info, causing error 
+          C1041 ("cannot open program database").
+        -->
+      <AdditionalOptions>/FS %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
### Why is this needed?
We currently have a vcpkg port for [vbs-enclave-tooling-codegen](https://vcpkg.io/en/package/vbs-enclave-tooling-codegen). I'm currently creating one for the sdk but ran into an issue building the veil solution via vcpkg. When building through vcpkg, multiple `cl.exe` processes attempt to write to the same `.pdb` file concurrently.  

Without the `/FS` ([Force Synchronous PDB Writes](/FS (Force Synchronous PDB Writes))) compiler option, this results in intermittent `C1041: cannot open program database` errors on different veil `.pdb` files.  

Although the solution builds successfully in Visual Studio and standalone `msbuild` runs, vcpkg’s parallelized build environment exposes this issue.  Adding `/FS` ensures reliable parallel compilation by serializing access to the `.pdb` file.

### What changed?
- Added `/FS` to the `<ClCompile>`  attribute of the **veil_enclave_lib** project
- This ensures the enclave library can build reliably in parallel builds across all supported platforms/configurations.

### How was it tested?
- Confirmed that I can still build all the codegen and veil solution via the build.ps1 script.
- Samples and codegen test solutions still build as well.
- Confirmed my local port `vbs-enclave-tooling-sdk` for built successfully
