### PR TITLE
Remove dependency on MsGSL from SDK

### DIFF
--- a/SampleApps/HelloWorld/ConsoleHostApp/ConsoleHostApp.vcxproj
+++ b/SampleApps/HelloWorld/ConsoleHostApp/ConsoleHostApp.vcxproj
@@ -2,7 +2,6 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.1.0-prerelease.250731.6\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.props" Condition="Exists('..\packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.1.0-prerelease.250731.6\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.props')" />
   <Import Project="..\packages\Microsoft.Windows.VbsEnclave.SDK.0.0.2-prerelease.250520.3\build\native\Microsoft.Windows.VbsEnclave.SDK.props" Condition="Exists('..\packages\Microsoft.Windows.VbsEnclave.SDK.0.0.2-prerelease.250520.3\build\native\Microsoft.Windows.VbsEnclave.SDK.props')" />
-  <Import Project="..\packages\MsGsl.3.1.0.2\build\native\MsGsl.props" Condition="Exists('..\packages\MsGsl.3.1.0.2\build\native\MsGsl.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM64">
       <Configuration>Debug</Configuration>
@@ -162,7 +161,6 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
-    <Error Condition="!Exists('..\packages\MsGsl.3.1.0.2\build\native\MsGsl.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MsGsl.3.1.0.2\build\native\MsGsl.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.VbsEnclave.SDK.0.0.2-prerelease.250520.3\build\native\Microsoft.Windows.VbsEnclave.SDK.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.VbsEnclave.SDK.0.0.2-prerelease.250520.3\build\native\Microsoft.Windows.VbsEnclave.SDK.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.VbsEnclave.SDK.0.0.2-prerelease.250520.3\build\native\Microsoft.Windows.VbsEnclave.SDK.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.VbsEnclave.SDK.0.0.2-prerelease.250520.3\build\native\Microsoft.Windows.VbsEnclave.SDK.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.1.0-prerelease.250731.6\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.1.0-prerelease.250731.6\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.props'))" />

--- a/SampleApps/HelloWorld/ConsoleHostApp/packages.config
+++ b/SampleApps/HelloWorld/ConsoleHostApp/packages.config
@@ -3,5 +3,4 @@
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
   <package id="Microsoft.Windows.VbsEnclave.CodeGenerator" version="0.1.0-prerelease.250731.6" targetFramework="native" />
   <package id="Microsoft.Windows.VbsEnclave.SDK" version="0.0.2-prerelease.250520.3" targetFramework="native" />
-  <package id="MsGsl" version="3.1.0.2" targetFramework="native" />
 </packages>

--- a/SampleApps/HelloWorld/MySecretVBSEnclave/MySecretVBSEnclave.vcxproj
+++ b/SampleApps/HelloWorld/MySecretVBSEnclave/MySecretVBSEnclave.vcxproj
@@ -2,7 +2,6 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.1.0-prerelease.250731.6\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.props" Condition="Exists('..\packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.1.0-prerelease.250731.6\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.props')" />
   <Import Project="..\packages\Microsoft.Windows.VbsEnclave.SDK.0.0.2-prerelease.250520.3\build\native\Microsoft.Windows.VbsEnclave.SDK.props" Condition="Exists('..\packages\Microsoft.Windows.VbsEnclave.SDK.0.0.2-prerelease.250520.3\build\native\Microsoft.Windows.VbsEnclave.SDK.props')" />
-  <Import Project="..\packages\MsGsl.3.1.0.2\build\native\MsGsl.props" Condition="Exists('..\packages\MsGsl.3.1.0.2\build\native\MsGsl.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM64">
       <Configuration>Debug</Configuration>
@@ -275,7 +274,6 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
-    <Error Condition="!Exists('..\packages\MsGsl.3.1.0.2\build\native\MsGsl.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MsGsl.3.1.0.2\build\native\MsGsl.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.VbsEnclave.SDK.0.0.2-prerelease.250520.3\build\native\Microsoft.Windows.VbsEnclave.SDK.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.VbsEnclave.SDK.0.0.2-prerelease.250520.3\build\native\Microsoft.Windows.VbsEnclave.SDK.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.VbsEnclave.SDK.0.0.2-prerelease.250520.3\build\native\Microsoft.Windows.VbsEnclave.SDK.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.VbsEnclave.SDK.0.0.2-prerelease.250520.3\build\native\Microsoft.Windows.VbsEnclave.SDK.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.1.0-prerelease.250731.6\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.1.0-prerelease.250731.6\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.props'))" />

--- a/SampleApps/HelloWorld/MySecretVBSEnclave/packages.config
+++ b/SampleApps/HelloWorld/MySecretVBSEnclave/packages.config
@@ -3,5 +3,4 @@
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
   <package id="Microsoft.Windows.VbsEnclave.CodeGenerator" version="0.1.0-prerelease.250731.6" targetFramework="native" />
   <package id="Microsoft.Windows.VbsEnclave.SDK" version="0.0.2-prerelease.250520.3" targetFramework="native" />
-  <package id="MsGsl" version="3.1.0.2" targetFramework="native" />
 </packages>

--- a/SampleApps/SampleApps/SampleApp1/SampleApp1.vcxproj
+++ b/SampleApps/SampleApps/SampleApp1/SampleApp1.vcxproj
@@ -5,7 +5,6 @@
   <Import Project="..\packages\Microsoft.Windows.SDK.CPP.10.0.26100.3916\build\native\Microsoft.Windows.SDK.cpp.props" Condition="Exists('..\packages\Microsoft.Windows.SDK.CPP.10.0.26100.3916\build\native\Microsoft.Windows.SDK.cpp.props')" />
   <Import Project="..\packages\Microsoft.Windows.VbsEnclave.SDK.0.0.0\build\native\Microsoft.Windows.VbsEnclave.SDK.props" Condition="Exists('..\packages\Microsoft.Windows.VbsEnclave.SDK.0.0.0\build\native\Microsoft.Windows.VbsEnclave.SDK.props')" />
   <Import Project="..\packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.0.0\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.props" Condition="Exists('..\packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.0.0\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.props')" />
-  <Import Project="..\packages\MsGsl.3.1.0.2\build\native\MsGsl.props" Condition="Exists('..\packages\MsGsl.3.1.0.2\build\native\MsGsl.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM64">
       <Configuration>Debug</Configuration>
@@ -168,7 +167,6 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
-    <Error Condition="!Exists('..\packages\MsGsl.3.1.0.2\build\native\MsGsl.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MsGsl.3.1.0.2\build\native\MsGsl.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.0.0\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.0.0\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.0.0\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.0.0\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.VbsEnclave.SDK.0.0.0\build\native\Microsoft.Windows.VbsEnclave.SDK.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.VbsEnclave.SDK.0.0.0\build\native\Microsoft.Windows.VbsEnclave.SDK.props'))" />

--- a/SampleApps/SampleApps/SampleApp1/packages.config
+++ b/SampleApps/SampleApps/SampleApp1/packages.config
@@ -6,5 +6,4 @@
   <package id="Microsoft.Windows.SDK.CPP.x64" version="10.0.26100.3916" targetFramework="native" />
   <package id="Microsoft.Windows.VbsEnclave.CodeGenerator" version="0.0.0" targetFramework="native" />
   <package id="Microsoft.Windows.VbsEnclave.SDK" version="0.0.0" targetFramework="native" />
-  <package id="MsGsl" version="3.1.0.2" targetFramework="native" />
 </packages>

--- a/SampleApps/SampleApps/SampleEnclave/SampleEnclave.vcxproj
+++ b/SampleApps/SampleApps/SampleEnclave/SampleEnclave.vcxproj
@@ -5,7 +5,6 @@
   <Import Project="..\packages\Microsoft.Windows.SDK.CPP.10.0.26100.3916\build\native\Microsoft.Windows.SDK.cpp.props" Condition="Exists('..\packages\Microsoft.Windows.SDK.CPP.10.0.26100.3916\build\native\Microsoft.Windows.SDK.cpp.props')" />
   <Import Project="..\packages\Microsoft.Windows.VbsEnclave.SDK.0.0.0\build\native\Microsoft.Windows.VbsEnclave.SDK.props" Condition="Exists('..\packages\Microsoft.Windows.VbsEnclave.SDK.0.0.0\build\native\Microsoft.Windows.VbsEnclave.SDK.props')" />
   <Import Project="..\packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.0.0\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.props" Condition="Exists('..\packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.0.0\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.props')" />
-  <Import Project="..\packages\MsGsl.3.1.0.2\build\native\MsGsl.props" Condition="Exists('..\packages\MsGsl.3.1.0.2\build\native\MsGsl.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM64">
       <Configuration>Debug</Configuration>
@@ -270,7 +269,6 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
-    <Error Condition="!Exists('..\packages\MsGsl.3.1.0.2\build\native\MsGsl.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MsGsl.3.1.0.2\build\native\MsGsl.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.0.0\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.0.0\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.0.0\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.0.0\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.VbsEnclave.SDK.0.0.0\build\native\Microsoft.Windows.VbsEnclave.SDK.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.VbsEnclave.SDK.0.0.0\build\native\Microsoft.Windows.VbsEnclave.SDK.props'))" />

--- a/SampleApps/SampleApps/SampleEnclave/packages.config
+++ b/SampleApps/SampleApps/SampleEnclave/packages.config
@@ -7,5 +7,4 @@
   <package id="Microsoft.Windows.SDK.CPP.x64" version="10.0.26100.3916" targetFramework="native" />
   <package id="Microsoft.Windows.VbsEnclave.CodeGenerator" version="0.0.0" targetFramework="native" />
   <package id="Microsoft.Windows.VbsEnclave.SDK" version="0.0.0" targetFramework="native" />
-  <package id="MsGsl" version="3.1.0.2" targetFramework="native" />
 </packages>

--- a/src/VbsEnclaveSDK/src/veil_enclave_lib/crypto.vtl1.h
+++ b/src/VbsEnclaveSDK/src/veil_enclave_lib/crypto.vtl1.h
@@ -5,7 +5,7 @@
 
 #include <span>
 #include <wil/stl.h>
-#include <gsl/gsl_util>
+#include "utils.vtl1.h"
 
 namespace veil::vtl1::crypto
 {
@@ -60,9 +60,9 @@ namespace veil::vtl1::crypto
         BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO cipherInfo {};
         BCRYPT_INIT_AUTH_MODE_INFO(cipherInfo);
         cipherInfo.pbNonce = const_cast<UCHAR*>(nonce.data());
-        cipherInfo.cbNonce = gsl::narrow_cast<ULONG>(nonce.size());;
+        cipherInfo.cbNonce = veil::vtl1::narrow_cast<ULONG>(nonce.size());;
         cipherInfo.pbTag = const_cast<UCHAR*>(tag.data());
-        cipherInfo.cbTag = gsl::narrow_cast<ULONG>(tag.size());
+        cipherInfo.cbTag = veil::vtl1::narrow_cast<ULONG>(tag.size());
         return cipherInfo;
     }
 
@@ -108,7 +108,7 @@ namespace veil::vtl1::crypto
             nullptr,
             0,
             const_cast<uint8_t*>(symmetricKeyBytes.data()),
-            gsl::narrow_cast<ULONG>(symmetricKeyBytes.size()),
+            veil::vtl1::narrow_cast<ULONG>(symmetricKeyBytes.size()),
             0));
 
         return S_OK;
@@ -142,7 +142,7 @@ namespace veil::vtl1::crypto
             BCRYPT_ECCPUBLIC_BLOB,
             &key,
             const_cast<PUCHAR>(keyBytes.data()),
-            gsl::narrow_cast<ULONG>(keyBytes.size()),
+            veil::vtl1::narrow_cast<ULONG>(keyBytes.size()),
             0));
         return key;
     }
@@ -193,12 +193,12 @@ namespace veil::vtl1::crypto
         NTSTATUS status = BCryptEncrypt(
             symmetricKey,
             const_cast<PBYTE>(plaintext.data()),
-            gsl::narrow_cast<ULONG>(plaintext.size()),
+            veil::vtl1::narrow_cast<ULONG>(plaintext.size()),
             const_cast<BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO*>(cipherInfo),
             nullptr,
             0,
             ciphertext.data(),
-            gsl::narrow_cast<ULONG>(ciphertext.size()),
+            veil::vtl1::narrow_cast<ULONG>(ciphertext.size()),
             &ciphertextSize,
             0);
 
@@ -297,7 +297,7 @@ namespace veil::vtl1::crypto
         UINT32 sealedSize = 0;
         THROW_IF_FAILED(::EnclaveSealData(
             unsealedData.data(),
-            gsl::narrow_cast<UINT32>(unsealedData.size()),
+            veil::vtl1::narrow_cast<UINT32>(unsealedData.size()),
             identityPolicy,
             runtimePolicy,
             nullptr,
@@ -307,7 +307,7 @@ namespace veil::vtl1::crypto
         auto sealedBytes = wil::secure_vector<uint8_t>(sealedSize);
         THROW_IF_FAILED(::EnclaveSealData(
             unsealedData.data(),
-            gsl::narrow_cast<UINT32>(unsealedData.size()),
+            veil::vtl1::narrow_cast<UINT32>(unsealedData.size()),
             identityPolicy,
             runtimePolicy,
             sealedBytes.data(),
@@ -322,7 +322,7 @@ namespace veil::vtl1::crypto
         UINT32 unsealedDataSize;
         THROW_IF_FAILED(::EnclaveUnsealData(
             sealedBytes.data(),
-            gsl::narrow_cast<UINT32>(sealedBytes.size()),
+            veil::vtl1::narrow_cast<UINT32>(sealedBytes.size()),
             nullptr,
             0,
             &unsealedDataSize,
@@ -333,7 +333,7 @@ namespace veil::vtl1::crypto
         auto unsealedBytes = wil::secure_vector<uint8_t>(unsealedDataSize);
         THROW_IF_FAILED(::EnclaveUnsealData(
             sealedBytes.data(),
-            gsl::narrow_cast<UINT32>(sealedBytes.size()),
+            veil::vtl1::narrow_cast<UINT32>(sealedBytes.size()),
             unsealedBytes.data(),
             unsealedDataSize,
             &unsealedDataSize,

--- a/src/VbsEnclaveSDK/src/veil_enclave_lib/logger.vtl1.h
+++ b/src/VbsEnclaveSDK/src/veil_enclave_lib/logger.vtl1.h
@@ -2,7 +2,6 @@
 
 #include <span>
 
-#include <gsl/gsl_util>
 #include <wil/stl.h>
 
 #include "..\veil_any_inc\logger.any.h"

--- a/src/VbsEnclaveSDK/src/veil_enclave_lib/packages.config
+++ b/src/VbsEnclaveSDK/src/veil_enclave_lib/packages.config
@@ -7,5 +7,4 @@
   <package id="Microsoft.Windows.SDK.CPP.arm64" version="10.0.26100.3916" targetFramework="native" />
   <package id="Microsoft.Windows.SDK.CPP.x64" version="10.0.26100.3916" targetFramework="native" />
   <package id="Microsoft.Windows.VbsEnclave.CodeGenerator" version="0.1.2-prerelease.250820.1" targetFramework="native" />
-  <package id="MsGsl" version="3.1.0.2" targetFramework="native" />
 </packages>

--- a/src/VbsEnclaveSDK/src/veil_enclave_lib/utils.vtl1.h
+++ b/src/VbsEnclaveSDK/src/veil_enclave_lib/utils.vtl1.h
@@ -74,6 +74,15 @@ namespace veil::vtl1
         THROW_WIN32_IF(ERROR_INCORRECT_SIZE, destination.size() != source.size());
         std::copy(source.begin(), source.end(), destination.begin());
     }
+
+    // We only need narrow_cast from Microsoft GSL, not the entire dependency. So, we reimplement it here
+    // to avoid pulling in all of GSL.
+    // See narrow_cast implementation: https://github.com/microsoft/GSL/blob/7e0943d20d3082b4f350a7e0c3088d2388e934de/include/gsl/util#L129
+    template <class T, class U>
+    constexpr T narrow_cast(U&& u) noexcept
+    {
+        return static_cast<T>(std::forward<U>(u));
+    }
 }
 
 namespace veil::vtl1

--- a/src/VbsEnclaveSDK/src/veil_enclave_lib/veil_enclave_lib.vcxproj
+++ b/src/VbsEnclaveSDK/src/veil_enclave_lib/veil_enclave_lib.vcxproj
@@ -3,7 +3,6 @@
   <Import Project="$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.x64.10.0.26100.3916\build\native\Microsoft.Windows.SDK.cpp.x64.props" Condition="Exists('..\..\packages\Microsoft.Windows.SDK.CPP.x64.10.0.26100.3916\build\native\Microsoft.Windows.SDK.cpp.x64.props')" />
   <Import Project="$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.10.0.26100.3916\build\native\Microsoft.Windows.SDK.cpp.props" Condition="Exists('..\..\packages\Microsoft.Windows.SDK.CPP.10.0.26100.3916\build\native\Microsoft.Windows.SDK.cpp.props')" />
   <Import Project="$(SolutionDir)packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.1.2-prerelease.250820.1\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.1.2-prerelease.250820.1\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.props')" />
-  <Import Project="$(SolutionDir)packages\MsGsl.3.1.0.2\build\native\MsGsl.props" Condition="Exists('$(SolutionDir)packages\MsGsl.3.1.0.2\build\native\MsGsl.props')" />
   <Import Project="$(SolutionDir)packages\Microsoft.Windows.SDK.BuildTools.10.0.26100.1742\build\Microsoft.Windows.SDK.BuildTools.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.BuildTools.10.0.26100.1742\build\Microsoft.Windows.SDK.BuildTools.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM64">
@@ -97,7 +96,7 @@
       <AdditionalIncludeDirectories>$(WindowsSdk_EnclaveIncludes_Path)\um;$(WindowsSdk_EnclaveIncludes_Path)\shared;$(WindowsSdk_EnclaveIncludes_Path)\ucrt;$(SolutionDir)..\..\Common\veil_enclave_wil_inc;$(MSBUILDThisFileDirectory)..\veil_enclave_inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <GuardEHContMetadata>true</GuardEHContMetadata>
-        <!-- 
+      <!-- 
           Add /FS to enable file-based locking on .pdb files. Without this, parallel cl.exe processes
           (as used by vcpkg builds) can collide when writing debug info, causing error 
           C1041 ("cannot open program database").
@@ -153,7 +152,6 @@
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.240803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.240803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.BuildTools.10.0.26100.1742\build\Microsoft.Windows.SDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.SDK.BuildTools.10.0.26100.1742\build\Microsoft.Windows.SDK.BuildTools.props'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.BuildTools.10.0.26100.1742\build\Microsoft.Windows.SDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.SDK.BuildTools.10.0.26100.1742\build\Microsoft.Windows.SDK.BuildTools.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)packages\MsGsl.3.1.0.2\build\native\MsGsl.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\MsGsl.3.1.0.2\build\native\MsGsl.props'))" />
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.1.2-prerelease.250820.1\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.1.2-prerelease.250820.1\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.props'))" />
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.1.2-prerelease.250820.1\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.1.2-prerelease.250820.1\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.10.0.26100.3916\build\native\Microsoft.Windows.SDK.cpp.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.SDK.CPP.10.0.26100.3916\build\native\Microsoft.Windows.SDK.cpp.props'))" />

--- a/src/VbsEnclaveSDK/src/veil_host_lib/packages.config
+++ b/src/VbsEnclaveSDK/src/veil_host_lib/packages.config
@@ -2,5 +2,4 @@
 <packages>
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
   <package id="Microsoft.Windows.VbsEnclave.CodeGenerator" version="0.1.2-prerelease.250820.1" targetFramework="native" />
-  <package id="MsGsl" version="3.1.0.2" targetFramework="native" />
 </packages>

--- a/src/VbsEnclaveSDK/src/veil_host_lib/veil_host_lib.vcxproj
+++ b/src/VbsEnclaveSDK/src/veil_host_lib/veil_host_lib.vcxproj
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.1.2-prerelease.250820.1\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.1.2-prerelease.250820.1\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.props')" />
-  <Import Project="$(SolutionDir)packages\MsGsl.3.1.0.2\build\native\MsGsl.props" Condition="Exists('$(SolutionDir)packages\MsGsl.3.1.0.2\build\native\MsGsl.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM64">
       <Configuration>Debug</Configuration>
@@ -143,7 +142,6 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.240803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.240803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)packages\MsGsl.3.1.0.2\build\native\MsGsl.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\MsGsl.3.1.0.2\build\native\MsGsl.props'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.1.2-prerelease.250820.1\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.1.2-prerelease.250820.1\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.props'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.1.2-prerelease.250820.1\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.VbsEnclave.CodeGenerator.0.1.2-prerelease.250820.1\build\native\Microsoft.Windows.VbsEnclave.CodeGenerator.targets'))" />
   </Target>

--- a/src/VbsEnclaveSDK/src/veil_nuget/Nuget/Microsoft.Windows.VbsEnclave.SDK.nuspec
+++ b/src/VbsEnclaveSDK/src/veil_nuget/Nuget/Microsoft.Windows.VbsEnclave.SDK.nuspec
@@ -18,7 +18,6 @@
     <dependencies>
         <group targetFramework="native">
             <dependency id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" />
-            <dependency id="MsGsl" version="3.1.0.2" />
         </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
The SDK currently uses a non official nuget package for MsGsl: https://www.nuget.org/packages/MsGsl. This is not maintained by Microsoft and hasn't been updated since 2022. 

We actually only use one function from MS GSL which is `narrow_cast<>()`. We don't have to pull in the whole gsl dependency, we can add their implementation to our repo and use that. 

### What was updated?
- Added vcpkg.json for the sdk with one dependency inside `ms-gsl`
- Removed the `#include` statements that contains `gsl/gsl_util` 
- Add `veil::vtl1::narrow_cast` which is just a copy of gsl's version and used that in place of `gsl::narrow_cast`
- Removed the MsGsl dependencies through the repo.

### How was it tested
- I confirmed no errors from the build script and was able to build the sdk without issue. 
- I confirmed the sample still build as expected