### PR TITLE
Add a version.h  and update enclave lib dependencies

### DIFF
--- a/src/ToolingNuget/Nuget/Microsoft.Windows.VbsEnclave.CodeGenerator.targets
+++ b/src/ToolingNuget/Nuget/Microsoft.Windows.VbsEnclave.CodeGenerator.targets
@@ -5,7 +5,6 @@
             The <VbsEnclaveCodegenPackageDir> should always point to this folder. Our targets file will be placed in
             <ProjectRoot>\packages\<name of nuget package>\build\native. 
          -->
-        <VbsEnclaveCodegenVersion Condition="'$(VbsEnclaveCodegenVersion)' == ''">0.0.0-Dev</VbsEnclaveCodegenVersion>
         <VbsEnclaveCodegenPackageDir>$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)))..\..\</VbsEnclaveCodegenPackageDir>
         <VbsEnclaveExeFilePath>$(VbsEnclaveCodegenPackageDir)bin\edlcodegen.exe</VbsEnclaveExeFilePath>
         <VbsEnclavePackageEnclaveAbiPath>$(VbsEnclaveCodegenPackageDir)src\VbsEnclaveABI</VbsEnclavePackageEnclaveAbiPath>
@@ -51,25 +50,47 @@
             <AdditionalIncludeDirectories>$(VcpkgIncludesDir);$(VbsEnclaveCodegenPackageDir)src\;$(VbsEnclaveGeneratedFilesDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
         </ClCompile>
 
-        <!-- define the __ENCLAVE_PROJECT__ macro in the enclave project so the enclave related ABI code lights up in the project.-->
-        <ClCompile Condition="'$(VbsEnclaveVirtualTrustLayer)' == 'Enclave'">
-            <PreprocessorDefinitions>__ENCLAVE_PROJECT__;__VBS_ENCLAVE_CODEGEN_VERSION__="$(VbsEnclaveCodegenVersion)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-        </ClCompile>
-
         <!-- The onecore.lib static library is required for host app projects. Add it by default to the host app-->
         <Link Condition="'$(VbsEnclaveVirtualTrustLayer)' == 'HostApp'">
             <AdditionalDependencies>onecore.lib;%(AdditionalDependencies)</AdditionalDependencies>
         </Link>
     </ItemDefinitionGroup>
 
-    <!-- Add enclave lib properties based on the platform. -->
-    <PropertyGroup Condition="'$(Platform)'=='x64' AND '$(VbsEnclaveVirtualTrustLayer)' == 'Enclave'">
-        <VC_LibraryPath_Enclave>$(VC_LibraryPath_VC_x64_Desktop)\..\$(Platform)\enclave</VC_LibraryPath_Enclave>
-        <VBS_Enclave_Dependencies Condition="'$(VBS_Enclave_Dependencies)' == ''">$(VC_LibraryPath_Enclave)\libcmt.lib;$(VC_LibraryPath_Enclave)\libvcruntime.lib;$(winsdk_cpp_x64_root)\um\x64\vertdll.lib;$(winsdk_cpp_x64_root)\um\x64\bcrypt.lib;$(winsdk_cpp_x64_root)\ucrt_enclave\x64\ucrt.lib</VBS_Enclave_Dependencies>
+    <PropertyGroup>
+        <NugetSdkRoot Condition="$(Platform) == x64">$(winsdk_cpp_x64_root)</NugetSdkRoot>
+        <NugetSdkRoot Condition="$(Platform) == ARM64">$(winsdk_cpp_arm64_root)</NugetSdkRoot>
+        <VC_LibraryPath_Enclave_Root Condition="$(Platform) == x64">$(VC_LibraryPath_VC_x64_Desktop)</VC_LibraryPath_Enclave_Root>
+        <VC_LibraryPath_Enclave_Root Condition="$(Platform) == ARM64">$(VC_LibraryPath_VC_ARM64_Desktop)</VC_LibraryPath_Enclave_Root>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(Platform)'=='ARM64' AND '$(VbsEnclaveVirtualTrustLayer)' == 'Enclave'">
-        <VC_LibraryPath_Enclave>$(VC_LibraryPath_VC_arm64_Desktop)\..\$(Platform)\enclave</VC_LibraryPath_Enclave>
-        <VBS_Enclave_Dependencies Condition="'$(VBS_Enclave_Dependencies)' == ''">$(VC_LibraryPath_Enclave)\libcmt.lib;$(VC_LibraryPath_Enclave)\libvcruntime.lib;$(winsdk_cpp_arm64_root)\um\arm64\vertdll.lib;$(winsdk_cpp_arm64_root)\um\arm64\bcrypt.lib;$(winsdk_cpp_arm64_root)\ucrt_enclave\arm64\ucrt.lib</VBS_Enclave_Dependencies>
+    <!--
+        Adds the vbs enclave dependency libs when the developer installs the Windows SDK via Nuget
+        instead of using the nuget packages.
+    -->   
+    <PropertyGroup
+        Condition="Exists('$(NugetSdkRoot)')">
+        <VBS_Enclave_Dependencies Condition="'$(VBS_Enclave_Dependencies)' == ''">
+            $(VC_LibraryPath_Enclave_Root)\..\$(Platform)\enclave\libcmt.lib;
+            $(VC_LibraryPath_Enclave_Root)\..\$(Platform)\enclave\libvcruntime.lib;
+            $(NugetSdkRoot)\um\$(Platform)\vertdll.lib;
+            $(NugetSdkRoot)\um\$(Platform)\bcrypt.lib;
+            $(NugetSdkRoot)\ucrt_enclave\$(Platform)\ucrt.lib
+        </VBS_Enclave_Dependencies>
+    </PropertyGroup>
+    
+    <!--
+        Adds the vbs enclave dependency libs when the developer Installs the Windows SDK via Visual Studio 
+        or through the MSI package.
+    -->
+    <PropertyGroup 
+        Label="EnclaveLibs"
+        Condition="!Exists('$(NugetSdkRoot)')">
+        <VBS_Enclave_Dependencies Condition="'$(VBS_Enclave_Dependencies)' == ''">
+            vertdll.lib;
+            bcrypt.lib;
+            $(VC_LibraryPath_Enclave_Root)\enclave\libcmt.lib;
+            $(VC_LibraryPath_Enclave_Root)\enclave\libvcruntime.lib;
+            $(WindowsSDK_LibraryPath)\..\ucrt_enclave\$(Platform)\ucrt.lib;
+        </VBS_Enclave_Dependencies>
     </PropertyGroup>
 </Project>

--- a/src/ToolingSharedLibrary/Includes/VbsEnclaveABI/Enclave/EnclaveHelpers.h
+++ b/src/ToolingSharedLibrary/Includes/VbsEnclaveABI/Enclave/EnclaveHelpers.h
@@ -2,17 +2,12 @@
 // Licensed under the MIT License.
 #pragma once 
 
-#if !defined(__ENCLAVE_PROJECT__)
-#error This header can only be included in an Enclave project (never the HostApp).
-#endif
-
-#if !defined(__VBS_ENCLAVE_CODEGEN_VERSION__)
-#error "VBS enclave code generator consumed without without version specified"
-#endif
+#include <wil\enclave\wil_for_enclaves.h>
 #include <VbsEnclaveABI\Enclave\MemoryAllocation.h>
 #include <VbsEnclaveABI\Enclave\Vtl0Pointers.h>
 #include <VbsEnclaveABI\Shared\ConversionHelpers.h>
 #include <VbsEnclaveABI\Shared\VbsEnclaveAbiBase.h>
+#include <VbsEnclaveABI\Shared\Version.h>
 
 // Version to ensure all translation units are consuming a consistent version of the codegen
 #pragma detect_mismatch("__VBS_ENCLAVE_CODEGEN_VERSION__", __VBS_ENCLAVE_CODEGEN_VERSION__)

--- a/src/ToolingSharedLibrary/Includes/VbsEnclaveABI/Enclave/MemoryAllocation.h
+++ b/src/ToolingSharedLibrary/Includes/VbsEnclaveABI/Enclave/MemoryAllocation.h
@@ -2,10 +2,7 @@
 // Licensed under the MIT License.
 #pragma once 
 
-#if !defined(__ENCLAVE_PROJECT__)
-#error This header can only be included in an Enclave project (never the HostApp).
-#endif
-
+#include <wil\enclave\wil_for_enclaves.h>
 #include <VbsEnclaveABI\Shared\VbsEnclaveAbiBase.h>
 #include <VbsEnclaveABI\Enclave\MemoryChecks.h>
 

--- a/src/ToolingSharedLibrary/Includes/VbsEnclaveABI/Enclave/MemoryChecks.h
+++ b/src/ToolingSharedLibrary/Includes/VbsEnclaveABI/Enclave/MemoryChecks.h
@@ -2,10 +2,7 @@
 // Licensed under the MIT License.
 #pragma once 
 
-#if !defined(__ENCLAVE_PROJECT__)
-#error This header can only be included in an Enclave project (never the HostApp).
-#endif
-
+#include <wil\enclave\wil_for_enclaves.h>
 #include <VbsEnclaveABI\Shared\VbsEnclaveAbiBase.h>
 #include <winenclaveapi.h>
 #include <ntenclv.h>

--- a/src/ToolingSharedLibrary/Includes/VbsEnclaveABI/Enclave/Vtl0Pointers.h
+++ b/src/ToolingSharedLibrary/Includes/VbsEnclaveABI/Enclave/Vtl0Pointers.h
@@ -3,10 +3,7 @@
 
 #pragma once 
 
-#if !defined(__ENCLAVE_PROJECT__)
-#error This header can only be included in an Enclave project (never the HostApp).
-#endif
-
+#include <wil\enclave\wil_for_enclaves.h>
 #include <VbsEnclaveABI\Shared\VbsEnclaveAbiBase.h>
 #include <VbsEnclaveABI\Enclave\MemoryAllocation.h>
 

--- a/src/ToolingSharedLibrary/Includes/VbsEnclaveABI/Shared/VbsEnclaveAbiBase.h
+++ b/src/ToolingSharedLibrary/Includes/VbsEnclaveABI/Shared/VbsEnclaveAbiBase.h
@@ -2,16 +2,6 @@
 // Licensed under the MIT License.
 #pragma once 
 
-// Must be the first header included for enclave dll's
-#ifdef __ENCLAVE_PROJECT__
-#pragma warning(push)
-#pragma warning(disable : 5260) // the constant variable has external\internal linkage: wistd_functional.h(278,28)
-#include <wil/enclave/wil_for_enclaves.h>
-#pragma warning(pop)
-#endif
-
-// end
-
 #include <array>
 #include <atomic>
 #include <cstdint>

--- a/src/ToolingSharedLibrary/Includes/VbsEnclaveABI/Shared/Version.h
+++ b/src/ToolingSharedLibrary/Includes/VbsEnclaveABI/Shared/Version.h
@@ -1,0 +1,8 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+// Auto-updated version file for edlcodgen.exe.
+// Manual changes will be overwritten.
+#define __VBS_ENCLAVE_CODEGEN_VERSION__ "0.0.0-Dev"

--- a/src/ToolingSharedLibrary/ToolingSharedLibrary.vcxproj
+++ b/src/ToolingSharedLibrary/ToolingSharedLibrary.vcxproj
@@ -229,13 +229,16 @@
     <ClCompile Include="ToolingExecutable\Edl\Parser.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="VersionHelper\helpers.targets" />
     <None Include="packages.config" />
     <None Include="README.md" />
     <None Include="vcpkg.json" />
+    <None Include="VersionHelper\Version.ps1" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+    <Import Project="$(ProjectDir)VersionHelper\helpers.targets"/>
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/ToolingSharedLibrary/VersionHelper/Version.ps1
+++ b/src/ToolingSharedLibrary/VersionHelper/Version.ps1
@@ -1,0 +1,34 @@
+# Generates version.h file for edlcodgen.exe static files.
+param (
+    [string]$VersionString,
+    [string]$OutputFile
+)
+
+# Ensure version string is provided
+if (-not $VersionString)
+{
+    Write-Error "Version string not specified."
+    exit 1
+}
+
+# Ensure output file path is provided
+if (-not $OutputFile)
+{
+    Write-Error "Output file not specified."
+    exit 1
+}
+
+$template = @"
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Auto-generated version file for edlcodgen.exe. Do not edit manually.
+#pragma once
+
+#define __VBS_ENCLAVE_CODEGEN_VERSION__ "{0}"
+"@
+
+$fileHeader = $template -f $VersionString
+
+$fileHeader | Out-File -FilePath $OutputFile -Encoding UTF8
+

--- a/src/ToolingSharedLibrary/VersionHelper/helpers.targets
+++ b/src/ToolingSharedLibrary/VersionHelper/helpers.targets
@@ -1,0 +1,21 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <Target Name="UpdateVersionHeader" BeforeTargets="Build">
+        <PropertyGroup>
+            <EffectiveCodeGenVersion Condition="'$(VbsEnclaveCodegenVersion)' == ''">0.0.0-Dev</EffectiveCodeGenVersion>
+            <EffectiveCodeGenVersion Condition="'$(VbsEnclaveCodegenVersion)' != ''">$(VbsEnclaveCodegenVersion)</EffectiveCodeGenVersion>
+            <VersionHeaderOutputFile>$(ProjectDir)includes\VbsEnclaveABI\Shared\Version.h</VersionHeaderOutputFile>
+        </PropertyGroup>
+
+        <WriteLinesToFile
+            Condition="!Exists('$(VersionHeaderOutputFile)')"
+            File="$(VersionHeaderOutputFile)"
+            Lines=""
+            Overwrite="true"
+        />
+
+        <!-- Generate the Version.h file with the correct version -->
+        <Exec Command="powershell -ExecutionPolicy Bypass -File &quot;$(ProjectDir)VersionHelper\Version.ps1&quot; -Version &quot;$(EffectiveCodeGenVersion)&quot; -OutputFile &quot;$(VersionHeaderOutputFile)&quot;" />
+    </Target>
+
+</Project>


### PR DESCRIPTION
### Why is this change needed
Currently, we pass `VbsEnclaveCodegenVersion` to MSBuild at build time so that the `__VBS_ENCLAVE_CODEGEN_VERSION__` macro is defined.  
However, once the codegen NuGet package is built and consumed, this value always defaults to `0.0.0-dev` unless the developer explicitly sets it.  

In practice, this means:
- The macro has always been `0.0.0-dev` regardless of the real build version.

### What changed
- Added a target + PowerShell script to auto-update `version.h` during codegen build. The build process updates `__VBS_ENCLAVE_CODEGEN_VERSION__` with the value inside `<VbsEnclaveCodegenVersion />`.  This now guarantees `__VBS_ENCLAVE_CODEGEN_VERSION__` always reflects the actual build version across updates.
- Removed the need for developers to manually set `__ENCLAVE_PROJECT__` and `__VBS_ENCLAVE_CODEGEN_VERSION__` in `<PreProcessorDefinitions/>`.  
- Unified enclave lib dependency setup so it works with both Windows SDK installs (VS/MSI) and NuGet.  

### How it was tested
- Verified SDK and codegen build cleanly via the build script.  
- Confirmed version mismatch errors now trigger correctly.  
