### PR TITLE
Pin cpp_ci to windows-2022 to fix VS2026 toolset/LTCG CI failures

### DIFF
--- a/.github/workflows/cpp_ci.yml
+++ b/.github/workflows/cpp_ci.yml
@@ -11,7 +11,11 @@ on:
 jobs:
   build-edl-code-gen:
     name: Build EdlCodeGen
-    runs-on: windows-latest
+    # Pinned to windows-2022 (Visual Studio 2022 / v143 toolset). The
+    # windows-latest image migrated to Visual Studio 2026 (v18) in June 2026,
+    # which does not reliably provide the v143 build tools these projects pin
+    # (MSB8020) and whose LTCG backend intermittently crashed with LNK1257.
+    runs-on: windows-2022
 
     strategy:
       matrix:
@@ -53,7 +57,8 @@ jobs:
             _build/${{ matrix.platform }}/${{ matrix.configuration }}/
   run-edl-code-gen-tests:
     name: Test EdlCodeGen
-    runs-on: windows-latest
+    # See note on the build-edl-code-gen job: pinned to VS2022 / v143.
+    runs-on: windows-2022
     needs: build-edl-code-gen
 
     strategy:
@@ -80,7 +85,8 @@ jobs:
 
   build-sdk:
     name: Build Veil SDK
-    runs-on: windows-latest
+    # See note on the build-edl-code-gen job: pinned to VS2022 / v143.
+    runs-on: windows-2022
 
     strategy:
       matrix:


### PR DESCRIPTION
This PR fixes the `cpp_ci` build failures by pinning the C++ CI jobs to the `windows-2022` runner image (Visual Studio 2022 / v143 toolset) instead of `windows-latest`.

The `windows-latest` image moved to Visual Studio 2026 (v18), which does not reliably provide the `v143` (VS2022) build tools that every project in the repo pins, so builds intermittently fail with `MSB8020: The build tools for Visual Studio 2022 (Platform Toolset = 'v143') cannot be found`; on runs where a v143 project did link, the VS2026 LTCG backend intermittently crashed with `LNK1257: code generation failed`. Both symptoms share the same root cause (the runner image change), which is why they appear on unrelated, content-free PRs (#203, #204).

## Details

* `.github/workflows/cpp_ci.yml`: change all three jobs (`build-edl-code-gen`, `run-edl-code-gen-tests`, `build-sdk`) from `runs-on: windows-latest` to `runs-on: windows-2022`, with a comment explaining the pin.

## Tests

* Confirmed from CI logs that failing jobs resolved to VS2026 (`...\Microsoft Visual Studio\18\Enterprise\...`, MSBuild 18.7.8): failing runs used the `v180` targets and reported MSB8020 for v143, while passing runs used the `v170` (v143) targets.
* `windows-2022` is a GitHub-supported runner image that ships VS2022 / v143, so it deterministically provides the pinned toolset.
* Validated `cpp_ci.yml` is well-formed YAML.

> [!NOTE]
> `pull_request` runs use the workflow file from the PR's head branch, so #203/#204 pick up this pin once they are rebased or retargeted onto this branch.